### PR TITLE
Faster magnetic field evaluation.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -6,7 +6,7 @@ env = init_environment("qt5 geant4 clhep evio xercesc ccdb")
 
 # env.Replace(CXX = "/apps/gcc/4.7.2/bin/g++")
 # env.Replace(CXX = "/usr/bin/clang++")
-#env.Append(CXXFLAGS='-Wno-shorten-64-to-32')
+env.Append(CXXFLAGS='-std=c++11')
 #env.Append(CXXFLAGS='-Wno-sign-conversion')
 
 # added because clhep is still behind clang (5/2015)

--- a/fields/asciiField.cc
+++ b/fields/asciiField.cc
@@ -149,7 +149,7 @@ gfield asciiField::loadField(string file, goptions opts)
 						/// selecting "interpolation" nodes. 
 						if(ee.tagName().toStdString() == "interpolation")   
 						{
-							gf.map->interpolation = assignAttribute(ee, "type", "none");
+							gf.map->interpolation = gMappedField::MapInterpolation::none;//assignAttribute(ee, "type", "none");
 						}
 						nn = nn.nextSibling();
 					}
@@ -200,17 +200,45 @@ void asciiField::loadFieldMap(gMappedField* map, double v)
 	cout << "  > Loading field map from " << map->identifier << " with symmetry: " << map->symmetry << endl;
 
 	// dipole field
-	if(map->symmetry == "dipole-x" || map->symmetry == "dipole-y" || map->symmetry == "dipole-z")
+	if( map->symmetry == "dipole-x" )
+        {
+                map->symmetryAxis = gMappedField::SymmetryAxis::x;
 		loadFieldMap_Dipole(map, v);
+        } 
+        else if( map->symmetry == "dipole-y" )
+        {
+                map->symmetryAxis = gMappedField::SymmetryAxis::y;
+		loadFieldMap_Dipole(map, v);
+        }
+        else if( map->symmetry == "dipole-z" )
+        {
+                map->symmetryAxis = gMappedField::SymmetryAxis::z;
+		loadFieldMap_Dipole(map, v);
+        }
 
 	// cylindrical field
-	if(map->symmetry == "cylindrical-x" || map->symmetry == "cylindrical-y" || map->symmetry == "cylindrical-z")
+	if( map->symmetry == "cylindrical-x")
+        {
+                map->symmetryAxis = gMappedField::SymmetryAxis::x;
 		loadFieldMap_Cylindrical(map, v);
+        }
+        else if( map->symmetry == "cylindrical-y" )
+        {
+                map->symmetryAxis = gMappedField::SymmetryAxis::y;
+		loadFieldMap_Cylindrical(map, v);
+        }
+        else if( map->symmetry == "cylindrical-z" )
+        {
+                map->symmetryAxis = gMappedField::SymmetryAxis::z;
+		loadFieldMap_Cylindrical(map, v);
+        }
 
-	// phi-segmented field
+        // phi-segmented field
 
-	if(map->symmetry == "phi-segmented")
-		loadFieldMap_phiSegmented(map, v);
+        if( map->symmetry == "phi-segmented")
+        {
+           loadFieldMap_phiSegmented(map, v);
+        }
 }
 
 

--- a/fields/field.cc
+++ b/fields/field.cc
@@ -153,7 +153,7 @@ ostream &operator<<(ostream &stream, gfield gf)
 			cout << "    - Coordinate:         " << gf.map->coordinates[i];
 		
 		cout << "    - Map Field Unit:     " << gf.map->unit << endl;
-		cout << "    - Map Interpolation:  " << gf.map->interpolation << endl;
+		cout << "    - Map Interpolation:  " << endl;//gf.map->interpolation << endl;
 
 		cout << "    - map origin:         x=" << gf.map->mapOrigin[0]
 			 << "mm, y=" << gf.map->mapOrigin[1]

--- a/fields/mappedField.cc
+++ b/fields/mappedField.cc
@@ -14,17 +14,21 @@ void gMappedField::GetFieldValue( const double point[3], double *Bfield) const
 	
 	Bfield[0] = Bfield[1] = Bfield[2] = 0;
 
-	// dipole field
-	if(symmetry == "dipole-x" || symmetry == "dipole-y" || symmetry == "dipole-z")
-		GetFieldValue_Dipole(Point, Bfield, FIRST_ONLY);
+        if(!(this->func_ptr_GetFieldValue)) SetFunctionPointer();
 
-	// phi-symmetric cylindrical field
-	if(symmetry == "cylindrical-x" || symmetry == "cylindrical-y" || symmetry == "cylindrical-z")
-		GetFieldValue_Cylindrical(Point, Bfield, FIRST_ONLY);
-	
-	// phi-segmented
-	if(symmetry == "phi-segmented")
-		GetFieldValue_phiSegmented(Point, Bfield, FIRST_ONLY);
+        (this->*func_ptr_GetFieldValue)(Point, Bfield, FIRST_ONLY);
+
+	//// dipole field
+	//if(symmetry == "dipole-x" || symmetry == "dipole-y" || symmetry == "dipole-z")
+	//	GetFieldValue_Dipole(Point, Bfield, FIRST_ONLY);
+
+	//// phi-symmetric cylindrical field
+	//if(symmetry == "cylindrical-x" || symmetry == "cylindrical-y" || symmetry == "cylindrical-z")
+	//	GetFieldValue_Cylindrical(Point, Bfield, FIRST_ONLY);
+	//
+	//// phi-segmented
+	//if(symmetry == "phi-segmented")
+	//	GetFieldValue_phiSegmented(Point, Bfield, FIRST_ONLY);
 	
 	if(verbosity == 99)
 		FIRST_ONLY = 99;
@@ -35,9 +39,8 @@ void gMappedField::GetFieldValue( const double point[3], double *Bfield) const
 
 
 
-gcoord gMappedField::getCoordinateWithSpeed(int speed)
+const gcoord& gMappedField::getCoordinateWithSpeed(int speed)
 {
-	gcoord dummy("na", 0, 0, 0, "na", 0);
 	
 	for(unsigned int i=0; i<coordinates.size(); i++)
 		if(coordinates[i].speed == speed) return coordinates[i];
@@ -113,10 +116,40 @@ void gMappedField::initializeMap()
 		cellSize[1] = (getCoordinateWithName("transverse").max   - startMap[1]) / (np[1] - 1);
 		cellSize[2] = (getCoordinateWithName("longitudinal").max - startMap[2]) / (np[2] - 1);
 	}
+
+
+	// dipole field
+	if(symmetry == "dipole-x" || symmetry == "dipole-y" || symmetry == "dipole-z")
+		func_ptr_GetFieldValue = &gMappedField::GetFieldValue_Dipole;
+
+	// phi-symmetric cylindrical field
+	if(symmetry == "cylindrical-x" || symmetry == "cylindrical-y" || symmetry == "cylindrical-z")
+		func_ptr_GetFieldValue = &gMappedField::GetFieldValue_Cylindrical;
+	
+	// phi-segmented
+	if(symmetry == "phi-segmented")
+		func_ptr_GetFieldValue = &gMappedField::GetFieldValue_phiSegmented;
+	
 	
 }
 
+void gMappedField::SetFunctionPointer() const {
 
+	func_ptr_GetFieldValue = &gMappedField::GetFieldValue_Dipole;
+
+	// dipole field
+	if(symmetry == "dipole-x" || symmetry == "dipole-y" || symmetry == "dipole-z")
+		func_ptr_GetFieldValue = &gMappedField::GetFieldValue_Dipole;
+
+	// phi-symmetric cylindrical field
+	if(symmetry == "cylindrical-x" || symmetry == "cylindrical-y" || symmetry == "cylindrical-z")
+		func_ptr_GetFieldValue = &gMappedField::GetFieldValue_Cylindrical;
+	
+	// phi-segmented
+	if(symmetry == "phi-segmented")
+		func_ptr_GetFieldValue = &gMappedField::GetFieldValue_phiSegmented;
+	
+}
 
 
 

--- a/fields/mappedField.h
+++ b/fields/mappedField.h
@@ -25,15 +25,9 @@ using namespace CLHEP;
 class gcoord
 {
 	public:
-		gcoord(string nm, unsigned int n, double m, double M, string u, int s)
-		{
-			name  = nm;
-			np    = n;
-			min   = m;
-			max   = M;
-			unit  = u;
-			speed = s;		
-		}
+		gcoord(string nm = "na", unsigned int n = 0, double m = 0, double M=0, string u="na", int s=0) :
+			name  ( nm ), np    ( n  ), min   ( m  ), max   ( M  ), unit  ( u  ), speed ( s  )
+		{ }
 	
 	public:
 		string       name;
@@ -42,6 +36,8 @@ class gcoord
 		double       max;
 		string       unit;
 		int          speed;     // 0 is the slowest varying coordinate
+
+
 
 		friend ostream &operator<<(ostream &stream, gcoord gc)
 		{
@@ -64,7 +60,6 @@ class gcoord
 };
 
 
-
 // define a mapped field
 /// \class gMappedField
 /// <b>gMappedField </b>\n\n
@@ -73,59 +68,80 @@ class gcoord
 /// returns a magnetic field value at a point in space
 class gMappedField : public G4MagneticField
 {
-	public:
-		gMappedField(string i, string s)
-		{		
-			symmetry      = s;
-			identifier    = i;
-			mapOrigin[0]  = 0;
-			mapOrigin[1]  = 0;
-			mapOrigin[2]  = 0;
-			scaleFactor   = 1;
-			unit          = "gauss";
-			interpolation = "none";
-			verbosity     = 0;
-		}
-	 ~gMappedField(){;}
-	
-		string symmetry;            ///< map symmetry
-		string identifier;          ///< Pointer to map in factory (for example, hostname / filename with path / date)
-		vector<gcoord> coordinates; ///< Vector size depend on the symmetry
-		
-		double mapOrigin[3];        ///< Displacement of map. This is used in GetFieldValue
-		double scaleFactor;         ///< copy of the gfield scaleFactor
-		string unit;                ///< field unit in the map
-		string interpolation;       ///< map interpolation technique. Choices are "none", "linear", "quadratic"
-		int verbosity;              ///< map verbosity
-		
-		// field depending on 3D map
-		double ***B1_3D;
-		double ***B2_3D;
-		double ***B3_3D;
-		
-		// field depending on 2D map
-		double **B1_2D;
-		double **B2_2D;
-		
-		// these are initialized based on the map
-		// symmetry and coordinates
-		// it will avoid the time spend in retrieving 
-		// the infos in GetFieldValue
-		double *startMap;
-		double *cellSize;
-		unsigned int *np;
-		void initializeMap();
-		
-		gcoord getCoordinateWithSpeed(int speed);   ///< return coordinate based on speed
-		gcoord getCoordinateWithName(string name);  ///< return coordinate based on type
-		
-		// returns the field at point x. This is a dispatcher for the various symmetries below
-		void GetFieldValue( const double x[3], double *Bfield) const;
-		
-		void GetFieldValue_Dipole( const double x[3], double *Bfield, int FIRST_ONLY) const;
-		void GetFieldValue_Cylindrical( const double x[3], double *Bfield, int FIRST_ONLY) const;
-		void GetFieldValue_phiSegmented( const double x[3], double *Bfield, int FIRST_ONLY) const;
-	
+   public:
+
+      enum class MapInterpolation {none, linear, quadratic}; 
+      enum class SymmetryAxis {x, y, z}; 
+
+      gMappedField(string i, string s)
+      {		
+         symmetryAxis  = SymmetryAxis::z;
+         symmetry      = s;
+         identifier    = i;
+         mapOrigin[0]  = 0;
+         mapOrigin[1]  = 0;
+         mapOrigin[2]  = 0;
+         scaleFactor   = 1;
+         unit          = "gauss";
+         interpolation = MapInterpolation::none;
+         verbosity     = 0;
+         func_ptr_GetFieldValue = 0;
+
+         double sqrt3 = sqrt(3.0);
+         //     angle=     0         60        120   180         240         300   360 
+         segment_sin = { 0.0, sqrt3/2.0, sqrt3/2.0,  0.0, -sqrt3/2.0, -sqrt3/2.0,  0.0 };
+         segment_cos = { 1.0,       0.5,      -0.5, -1.0,       -0.5,        0.5,  1.0 };
+
+      }
+      ~gMappedField(){;}
+
+      SymmetryAxis  symmetryAxis;
+      string symmetry;            ///< map symmetry
+      string identifier;          ///< Pointer to map in factory (for example, hostname / filename with path / date)
+      vector<gcoord> coordinates; ///< Vector size depend on the symmetry
+
+      double mapOrigin[3];        ///< Displacement of map. This is used in GetFieldValue
+      double scaleFactor;         ///< copy of the gfield scaleFactor
+      string unit;                ///< field unit in the map
+      MapInterpolation interpolation;
+      //string interpolation;       ///< map interpolation technique. Choices are "none", "linear", "quadratic"
+      int verbosity;              ///< map verbosity
+
+      vector<double>   segment_sin;
+      vector<double>   segment_cos;
+
+      // field depending on 3D map
+      double ***B1_3D;
+      double ***B2_3D;
+      double ***B3_3D;
+
+      // field depending on 2D map
+      double **B1_2D;
+      double **B2_2D;
+
+      // these are initialized based on the map
+      // symmetry and coordinates
+      // it will avoid the time spend in retrieving 
+      // the infos in GetFieldValue
+      double *startMap;
+      double *cellSize;
+      unsigned int *np;
+      void initializeMap();
+
+      const gcoord& getCoordinateWithSpeed(int speed);   ///< return coordinate based on speed
+      gcoord getCoordinateWithName(string name);  ///< return coordinate based on type
+      gcoord dummy;
+
+      // returns the field at point x. This is a dispatcher for the various symmetries below
+      void GetFieldValue( const double x[3], double *Bfield) const;
+
+      void SetFunctionPointer() const;
+      mutable void (gMappedField::*func_ptr_GetFieldValue)( const double x[3], double *Bfield, int) const ;
+
+      void GetFieldValue_Dipole( const double x[3], double *Bfield, int FIRST_ONLY) const;
+      void GetFieldValue_Cylindrical( const double x[3], double *Bfield, int FIRST_ONLY) const;
+      void GetFieldValue_phiSegmented( const double x[3], double *Bfield, int FIRST_ONLY) const;
+
 };
 
 #endif

--- a/fields/symmetries/cylindrical.cc
+++ b/fields/symmetries/cylindrical.cc
@@ -119,28 +119,38 @@ void gMappedField::GetFieldValue_Cylindrical( const double x[3], double *Bfield,
 {
 	double LC  = 0;    // longitudinal
 	double TC  = 0;    // transverse
-	double phi = 0;    // phi angle
+	//double phi = 0;    // phi angle
+        double cos_phi =  1.0;
+        double sin_phi =  0.0;
 		
 	// map plane is in ZX, phi on X axis
-	if(symmetry == "cylindrical-z") 
+	if( symmetryAxis == SymmetryAxis::z ) 
 	{
 		LC  = x[2];
 		TC  = sqrt(x[0]*x[0] + x[1]*x[1]);
-		phi = G4ThreeVector(x[0], x[1], x[2]).phi();
+		//phi = G4ThreeVector(x[0], x[1], x[2]).phi();
+                cos_phi = x[0]/TC;
+                sin_phi = x[1]/TC;
 	}
 	// map plane is in XY, phi on Y axis
-	else if(symmetry == "cylindrical-x")
-	{
+        //else if(symmetry == "cylindrical-x")
+        else if( symmetryAxis == SymmetryAxis::x ) 
+        {
 		LC  = x[0];
 		TC  = sqrt(x[1]*x[1] + x[2]*x[2]);
-		phi = G4ThreeVector(x[2], x[0], x[1]).phi();
+		//phi = G4ThreeVector(x[2], x[0], x[1]).phi();
+                cos_phi = x[2]/TC;
+                sin_phi = x[0]/TC;
 	}
 	// map plane is in XZ, phi on Z axis
-	else if(symmetry == "cylindrical-y")
+	//else if(symmetry == "cylindrical-y")
+        else if( symmetryAxis == SymmetryAxis::y ) 
 	{
 		LC  = x[1];
 		TC  = sqrt(x[0]*x[0] + x[2]*x[2]);
-		phi = G4ThreeVector(x[1], x[2], x[0]).phi();
+		//phi = G4ThreeVector(x[1], x[2], x[0]).phi();
+                cos_phi = x[1]/TC;
+                sin_phi = x[2]/TC;
 	}
 
 	// map indexes, bottom of the cell
@@ -153,27 +163,28 @@ void gMappedField::GetFieldValue_Cylindrical( const double x[3], double *Bfield,
 
 	// outside map, returning no field
 	if(IT>=np[0] || IL>=np[1]) return;
+
 	
 	// no interpolation
-	if(interpolation == "none")
+	if(interpolation == MapInterpolation::none)
 	{
-		if(symmetry == "cylindrical-z") 
+		if(symmetryAxis == SymmetryAxis::z) 
 		{
-			Bfield[0] = B1_2D[IT][IL] * cos(phi);
-			Bfield[1] = B1_2D[IT][IL] * sin(phi);
+			Bfield[0] = B1_2D[IT][IL] * cos_phi;
+			Bfield[1] = B1_2D[IT][IL] * sin_phi;
 			Bfield[2] = B2_2D[IT][IL];
-		}
-		else if(symmetry == "cylindrical-x")
-		{
+                }
+                else if(symmetryAxis == SymmetryAxis::x) 
+                {
 			Bfield[0] = B2_2D[IT][IL];
-			Bfield[1] = B1_2D[IT][IL] * cos(phi);
-			Bfield[2] = B1_2D[IT][IL] * sin(phi);
+			Bfield[1] = B1_2D[IT][IL] * cos_phi;
+			Bfield[2] = B1_2D[IT][IL] * sin_phi;
 		}
-		else if(symmetry == "cylindrical-y")
+                else if(symmetryAxis == SymmetryAxis::y) 
 		{
 			Bfield[1] = B2_2D[IT][IL];
-			Bfield[0] = B1_2D[IT][IL] * sin(phi);
-			Bfield[2] = B1_2D[IT][IL] * cos(phi);
+			Bfield[0] = B1_2D[IT][IL] * sin_phi;
+			Bfield[2] = B1_2D[IT][IL] * cos_phi;
 		}
 	}
 
@@ -182,6 +193,7 @@ void gMappedField::GetFieldValue_Cylindrical( const double x[3], double *Bfield,
 	// so we can output units as well
 	if(verbosity>3 && FIRST_ONLY != 99)
 	{
+           double phi = 0;
 		cout << "  > Track position in magnetic field: "
 			 << "("  << (x[0] + mapOrigin[0])/cm << ", "
 			         << (x[1] + mapOrigin[1])/cm << ", "

--- a/fields/symmetries/dipole.cc
+++ b/fields/symmetries/dipole.cc
@@ -142,7 +142,7 @@ void gMappedField::GetFieldValue_Dipole( const double x[3], double *Bfield, int 
 	if(IL>=np[0] || IT>=np[1]) return;
 	
 	// no interpolation
-	if(interpolation == "none")
+	if(interpolation == MapInterpolation::none)
 	{
 		if(symmetry == "dipole-x") Bfield[0] = B1_2D[IL][IT];
 		if(symmetry == "dipole-y") Bfield[1] = B1_2D[IL][IT];


### PR DESCRIPTION
Speed improvements come from the following changes.
- Removing unnecessary use of strings.
- Removing extra trig function evaluations.
- Adding enumerated types.
- Using a function pointer set at initialization.
- Changes require geant4 with C++11 support (or alternatively to not use the GEANT4 CXX flags)

Note that the function pointer could be avoided if each field symmetry was its own field class.
This would greatly simplify the field evaluation _and_ would remove the function pointer and enumerated type associated with the previous string usage.
