### PR TITLE
Ec hit process

### DIFF
--- a/hitprocess/clas12/ec_hitprocess.h
+++ b/hitprocess/clas12/ec_hitprocess.h
@@ -14,10 +14,10 @@ class ecConstants
 	
 		double NSTRIPS;              // Number of strips
 		double attlen;               // Attenuation Length (mm)
-		double TDC_time_to_channel;  // conversion from time (ns) to TDC channels.
-		double ECfactor;             // number of p.e. divided by the energy deposited in MeV; value taken from gsim. see EC NIM paper table 1.
-		int TDC_MAX;                 // max value for EC tdc.
-		double ec_MeV_to_channel;    // conversion from energy (MeV) to ADC channels
+		double TDC_time_to_evio;     // Conversion from time (ns) to EVIO TDC format
+		double ADC_MeV_to_evio;      // Conversion from energy (MeV) to EVIO FADC250 format
+		double PE_yld;               // Number of p.e. divided by the energy deposited in MeV. See EC NIM paper table 1.
+		double veff;                 // Effective velocity of scintillator light (mm/ns)
 };
 
 

--- a/hitprocess/clas12/pcal_hitprocess.h
+++ b/hitprocess/clas12/pcal_hitprocess.h
@@ -1,11 +1,23 @@
 #ifndef PCAL_HITPROCESS_H
 #define PCAL_HITPROCESS_H 1
 
-// %%%%%%%%%%%%%
 // gemc headers
-// %%%%%%%%%%%%%
 #include "HitProcess.h"
 
+// pc constants
+// these are loaded with initWithRunNumber
+class pcConstants
+{
+	public:
+		// runNo is mandatory variable to keep track of run number changes
+		int runNo;
+	
+		double attlen;               // Attenuation Length (mm)
+		double TDC_time_to_evio;     // Conversion from time (ns) to EVIO TDC format
+		double ADC_MeV_to_evio;      // Conversion from energy (MeV) to EVIO FADC250 format
+		double PE_yld;               // Number of p.e. divided by the energy deposited in MeV. 
+		double veff;                 // Effective velocity of scintillator light (mm/ns)
+};
 
 // Class definition
 class pcal_HitProcess : public HitProcess
@@ -14,6 +26,11 @@ class pcal_HitProcess : public HitProcess
 	
 		~pcal_HitProcess(){;}
 	
+		// constants initialized with initWithRunNumber
+		static pcConstants pcc;
+	
+		void initWithRunNumber(int runno);
+
 		// - integrateDgt: returns digitized information integrated over the hit
 		map<string, double> integrateDgt(MHit*, int);
 		


### PR DESCRIPTION
1. I added pcConstants class to organize hardwired constants similar to ecConstants.  
2. Renamed some constants.
3. Added new constants for effective velocity.
4. Previous hitprocess did not propagate light along strip.  This has been added for both EC and PCAL.
5. TDC dgtz now corresponds to current online EVIO format (24 ps / count).  EVIO TDC data in composite bank is in ps, not counts, from both 1190 and 1290 TDCs.  This is Sergey's choice.

Plots below show test of these changes.  Top plot shows EC data from forward carriage, bottom panel show GEMC simulation throwing muons from region of target.  Each panel shows U time plotted vs. V strip (as proxy for distance).  Y axis is actually U-V, time difference of U and V in ns.   For example, U22 plot is time difference of U22 PMT and each of the V strips that the muon went through in coincidence.

![t158](https://cloud.githubusercontent.com/assets/10797791/9411884/c36688dc-47f6-11e5-9f18-03894f12b427.png)
![tgemc](https://cloud.githubusercontent.com/assets/10797791/9411889/c7ae6608-47f6-11e5-8930-e7dc5316ea10.png)
 
