### PR TITLE
fmt and bmt new stripsID computation

### DIFF
--- a/hitprocess/clas12/micromegas/FMT_hitprocess.cc
+++ b/hitprocess/clas12/micromegas/FMT_hitprocess.cc
@@ -14,7 +14,8 @@ map<string, double>FMT_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 	// FMT ID:
 	// layer, type, sector, strip
 	
-	int layer  = 2*identity[0].id + identity[1].id - 2 ;
+	int layer  = 1*identity[0].id + identity[1].id - 1 ; // modified on 7/27/2015 to match new geometry (Frederic Georges)
+	//int layer  = 2*identity[0].id + identity[1].id - 2 ;
 	int sector = identity[2].id;
 	int strip  = identity[3].id;
 	
@@ -47,7 +48,8 @@ vector<identifier>  FMT_HitProcess :: processID(vector<identifier> id, G4Step* a
 	class fmt_strip fmts;
 	fmts.fill_infos();
 	
-	int layer  = 2*yid[0].id + yid[1].id - 2 ;
+	int layer  = 1*yid[0].id + yid[1].id - 1 ; // modified on 7/27/2015 to match new geometry (Frederic Georges)
+	//int layer  = 2*yid[0].id + yid[1].id - 2 ;
 	int sector = yid[2].id;
 	
 	//yid[3].id = fmts.FindStrip(layer-1, sector-1, x, y, z);

--- a/hitprocess/clas12/micromegas/bmt_strip.cc
+++ b/hitprocess/clas12/micromegas/bmt_strip.cc
@@ -10,9 +10,7 @@ void bmt_strip::fill_infos()
  // all dimensions are in mm
 
  Pi  = 3.14159265358;
- interlayer 	= 16.0;
- pitchZ      	= 0.540;
- pitchC      	= 0.270;
+ interlayer 	= 15.0;
  Nsector    	= 3;
  hDrift         = 3.0;
  hStrip2Det 	= hDrift/2.;
@@ -20,30 +18,100 @@ void bmt_strip::fill_infos()
  theta_L        = Pi*20./180.;
  w_i            = 25.0;
 
- DZ_inLength = 7.5;
- DZ_inWidth  = 7.5;
+
+ interStripZ = 0.201;
+ interStripC = 0.160;
+
+ // pitch CR4Z
+ pitchZ4 = 0.487; // and interpitch=0.201
+ 
+ // pitch CR5Z
+ pitchZ5 = 0.49; // none existing value. picked a rabdom value compatible with the geometry
+ 
+ // pitch CR6Z
+ pitchZ6 = 0.526; // interpitch=0.201 ; 0.526 = 0.201 + 0.325
+
+ // pitch CR4C
+ pitchC4.push_back(0.505); // 32 strips
+ pitchC4.push_back(0.440); // 32 strips
+ pitchC4.push_back(0.385); // 32 strips
+ pitchC4.push_back(0.335); // 32 strips
+ pitchC4.push_back(0.330); // 8 * 64 strips
+ pitchC4.push_back(0.370); // 32 strips
+ pitchC4.push_back(0.420); // 32 strips
+ pitchC4.push_back(0.470); // 32 strips
+ pitchC4.push_back(0.530); // 32 strips
+ pitchC4.push_back(0.600); // 32 strips
+ pitchC4.push_back(0.675); // 32 strips
+ pitchC4.push_back(0.765); // 32 strips
+ pitchC4.push_back(0.860); // 32 strips
+ 						   // 14 * 64
+ 
+ // pitch CR5C
+ // none existing value. picked a random value compatible with the geometry
+ pitchC5.push_back(0.413); // 16 groupes de 64
+ 						   // 16 * 64
+ 
+ // pitch CR6C
+ pitchC6.push_back(0.54); // 32 strips
+ pitchC6.push_back(0.48); // 32 strips
+ pitchC6.push_back(0.43); // 32 strips
+ pitchC6.push_back(0.39); // 32 strips
+ pitchC6.push_back(0.33); // 11 * 64 strips
+ pitchC6.push_back(0.34); // 32 strips
+ pitchC6.push_back(0.38); // 32 strips
+ pitchC6.push_back(0.41); // 32 strips
+ pitchC6.push_back(0.45); // 32 strips
+ pitchC6.push_back(0.49); // 32 strips
+ pitchC6.push_back(0.53); // 32 strips
+ pitchC6.push_back(0.57); // 32 strips
+ pitchC6.push_back(0.62); // 32 strips
+ pitchC6.push_back(0.67); // 32 strips
+ 						  // 18 * 64
 
  // z of the upstream part of the layer
- Z0.push_back(-127.000);  Z0.push_back(-127.000);
- Z0.push_back(-148.000); Z0.push_back(-148.000);
- Z0.push_back(-172.500); Z0.push_back(-172.500);
+ Z0.push_back(-127.820);  Z0.push_back(-127.820);
+ Z0.push_back(-148.740); Z0.push_back(-148.740);
+ Z0.push_back(-169.710); Z0.push_back(-169.710);
  
 // total z length of the layer of the layer
- DZ.push_back(370.5);  DZ.push_back(370.5);
- DZ.push_back(420.1); DZ.push_back(420.1);
- DZ.push_back(444.6); DZ.push_back(444.6);
+ DZ.push_back(372.75);  DZ.push_back(372.75);
+ DZ.push_back(423.99); DZ.push_back(423.99);
+ DZ.push_back(444.96); DZ.push_back(444.96);
 
  // radii of layers
- R.push_back(146.900); R.push_back(R[0]+interlayer);
- R.push_back(178.900); R.push_back(R[2]+interlayer);
- R.push_back(210.900); R.push_back(R[4]+interlayer);
+ R.push_back(145.731); R.push_back(R[0]+interlayer);
+ R.push_back(175.731); R.push_back(R[2]+interlayer);
+ R.push_back(205.731); R.push_back(R[4]+interlayer);
 
  // Number of strips (depends on radius, dead zones, and pitch!)
  for(int i=0;i<6;i++)
    { // layer 0,2,4 are Z detectors, i.e. measure phi (strips along z)
-     if((i%2)==0) Nstrips.push_back((int) ((2.*Pi*R[i]/((double) Nsector)-2.*DZ_inLength)/pitchZ));
-     if((i%2)==1) Nstrips.push_back((int) ((DZ[i]-2.*DZ_inWidth)/pitchC));
+     if(i==0) Nstrips.push_back(14*64); // CR4C
+     if(i==1) Nstrips.push_back(10*64); // CR4Z
+	 if(i==2) Nstrips.push_back(11*64); // CR5Z
+	 if(i==3) Nstrips.push_back(16*64); // CR5C
+	 if(i==4) Nstrips.push_back(12*64); // CR6Z
+	 if(i==5) Nstrips.push_back(18*64); // CR6C
    }
+ 
+ // dead angles
+ Inactivtheta.push_back((20/R[0])*(180./Pi));
+ Inactivtheta.push_back((20/R[1])*(180./Pi));
+ Inactivtheta.push_back((20/R[2])*(180./Pi));
+ Inactivtheta.push_back((20/R[3])*(180./Pi));
+ Inactivtheta.push_back((20/R[4])*(180./Pi));
+ Inactivtheta.push_back((20/R[5])*(180./Pi));
+ 
+ // dead zones
+ DZ_inLength = 0; //for CRnZ
+ DZ_inWidth  = 0; //for CRnC
+ DZ4_inLength = ((R[1]*(120-Inactivtheta[1])*Pi/180)-(Nstrips[1]*pitchZ4+interStripZ))/2; //for CR4Z (((160.731*(120-7.129)*Pi/180)-(10*64*0.487)+0.201))/2 = 2.377
+ DZ4_inWidth  = (DZ[0]-372.48-interStripC)/2; //for CR4C // (372.75 - 372.48 - 0.16)/2 = 0.055
+ DZ5_inLength = ((R[2]*(120-Inactivtheta[2])*Pi/180)-(Nstrips[2]*pitchZ4+interStripZ))/2; //for CR5Z (((175.731*(120-6.521)*Pi/180)-(11*64*0.49)+0.201))/2 = 1.444
+ DZ5_inWidth  = (DZ[3]-422.912-interStripC)/2; //for CR5C // (423.99 - 422.912 - 0.16)/2 = 0.459
+ DZ6_inLength = ((R[4]*(120-Inactivtheta[4])*Pi/180)-(Nstrips[4]*pitchZ4+interStripZ))/2; //for CR6Z (((205.731*(120-5.57)*Pi/180)-(12*64*0.526)+0.201))/2 = 1.779
+ DZ6_inWidth  = (DZ[5]-444.8-interStripC)/2; //for CR6C // (444.96 - 44.8 - 0.16)/2 = 0
  
  // mid angle of the sector
  MidTile.push_back(0);     MidTile.push_back(0);
@@ -57,6 +125,20 @@ vector<double>  bmt_strip::FindStrip(int layer, int sector, double x, double y, 
   // The first number is the ID, 
   // the second number is the sharing percentage
   vector<double> strip_id;
+  
+  // dead zones
+  if(layer == 0 || layer == 1){
+	DZ_inLength = DZ4_inLength;
+	DZ_inWidth  = DZ4_inWidth;
+  }
+  else if(layer == 2 || layer == 3){
+	DZ_inLength = DZ5_inLength;
+	DZ_inWidth  = DZ5_inWidth;
+  }
+  else if(layer == 4 || layer == 5){
+	DZ_inLength = DZ6_inLength;
+	DZ_inWidth  = DZ6_inWidth;
+  }
   
  // number of electrons (Nt)
  Nel = (int) (1e6*Edep/w_i);
@@ -88,23 +170,154 @@ vector<double>  bmt_strip::FindStrip(int layer, int sector, double x, double y, 
  int ClosestStrip=0;
  
  // now compute the sigma of the (transverse) dispersion for this interaction
- if((layer%2)==1) sigma_td = sigma_td_max* sqrt((sqrt(x*x+y*y)-R[layer]+hStrip2Det)/hDrift); // "C" det, transverse diffusion grows with square root of distance
+ if(layer==0 || layer==3 || layer==5) sigma_td = sigma_td_max* sqrt((sqrt(x*x+y*y)-R[layer]+hStrip2Det)/hDrift); // "C" det, transverse diffusion grows with square root of distance
  else sigma_td = sigma_td_max* sqrt((sqrt(x*x+y*y)-R[layer]+hStrip2Det)/(cos(theta_L)*hDrift)); // same, but "Z" detectors, so Lorentz angle makes drift distance longer by 1./cos(theta_L) . Means sigma_td can be larger than sigma_td_max
+
 
  if(Nel>0)
    {
      for(int iel=0;iel<Nel;iel++)
        { // loop over (total) electrons
-	 if((layer%2)==1) 
-	   { // this for "C" layers, i.e. measuring z
+	 
+	 if(layer==0) 
+	   { // this for "C4" layers, i.e. measuring z
+	  	 z_real = (double) (G4RandGauss::shoot(z,sigma_td));
+		 if(z_real-Z0[layer]-DZ_inWidth>0 && z_real-Z0[layer]-DZ_inWidth<=16.16)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth)/pitchC4[0]))+0.5);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>16.16 && z_real-Z0[layer]-DZ_inWidth<=30.24)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-16.16)/pitchC4[1]))+0.5+32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>30.24 && z_real-Z0[layer]-DZ_inWidth<=42.56)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-30.24)/pitchC4[2]))+0.5+2*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>42.56 && z_real-Z0[layer]-DZ_inWidth<=53.28)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-42.56)/pitchC4[3]))+0.5+3*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>53.28 && z_real-Z0[layer]-DZ_inWidth<=222.24)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-53.28)/pitchC4[4]))+0.5+4*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>222.24 && z_real-Z0[layer]-DZ_inWidth<=234.08)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-222.24)/pitchC4[5]))+0.5+20*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>234.08 && z_real-Z0[layer]-DZ_inWidth<=247.52)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-234.08)/pitchC4[6]))+0.5+21*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>247.52 && z_real-Z0[layer]-DZ_inWidth<=262.56)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-247.52)/pitchC4[7]))+0.5+22*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>262.56 && z_real-Z0[layer]-DZ_inWidth<=279.52)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-262.56)/pitchC4[8]))+0.5+23*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>279.52 && z_real-Z0[layer]-DZ_inWidth<=298.72)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-279.52)/pitchC4[9]))+0.5+24*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>298.72 && z_real-Z0[layer]-DZ_inWidth<=320.32)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-298.72)/pitchC4[10]))+0.5+25*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>320.32 && z_real-Z0[layer]-DZ_inWidth<=344.80)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-320.32)/pitchC4[11]))+0.5+26*32);
+		 }
+		 else if(z_real-Z0[layer]-DZ_inWidth>344.80 && z_real-Z0[layer]-DZ_inWidth<=372.32)
+		 {
+		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-344.80)/pitchC4[12]))+0.5+27*32);
+		 } 
+	   }
+	 else if(layer==3) 
+	   { // this for "C5" layers, i.e. measuring z
 	     z_real = (double) (G4RandGauss::shoot(z,sigma_td));
-	     ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth)/pitchC))+0.5);
+	     ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth)/pitchC5[0]))+0.5);
 	   }
-	 if((layer%2)==0)
-	   { // this for "Z" layers, i.e. measuring phi
+  	 else if(layer==5) 
+  	   { // this for "C6" layers, i.e. measuring z
+  	  	 z_real = (double) (G4RandGauss::shoot(z,sigma_td));
+  		 if(z_real-Z0[layer]-DZ_inWidth>0 && z_real-Z0[layer]-DZ_inWidth<=17.28)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth)/pitchC6[0]))+0.5);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>17.28 && z_real-Z0[layer]-DZ_inWidth<=32.64)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-17.28)/pitchC6[1]))+0.5+32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>32.64 && z_real-Z0[layer]-DZ_inWidth<=46.4)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-32.64)/pitchC6[2]))+0.5+2*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>46.4 && z_real-Z0[layer]-DZ_inWidth<=58.88)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-46.4)/pitchC6[3]))+0.5+3*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>58.88 && z_real-Z0[layer]-DZ_inWidth<=291.2)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-58.88)/pitchC6[4]))+0.5+4*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>291.2 && z_real-Z0[layer]-DZ_inWidth<=312.96)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-291.2)/pitchC6[5]))+0.5+26*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>312.96 && z_real-Z0[layer]-DZ_inWidth<=325.12)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-312.96)/pitchC6[6]))+0.5+28*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>325.12 && z_real-Z0[layer]-DZ_inWidth<=338.24)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-325.12)/pitchC6[7]))+0.5+29*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>338.24 && z_real-Z0[layer]-DZ_inWidth<=352.64)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-338.24)/pitchC6[8]))+0.5+30*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>352.64 && z_real-Z0[layer]-DZ_inWidth<=368.32)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-352.64)/pitchC6[9]))+0.5+31*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>368.32 && z_real-Z0[layer]-DZ_inWidth<=385.28)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-368.32)/pitchC6[10]))+0.5+32*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>385.28 && z_real-Z0[layer]-DZ_inWidth<=403.52)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-385.28)/pitchC6[11]))+0.5+33*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>403.52 && z_real-Z0[layer]-DZ_inWidth<=423.36)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-403.52)/pitchC6[12]))+0.5+34*32);
+  		 }
+  		 else if(z_real-Z0[layer]-DZ_inWidth>423.36 && z_real-Z0[layer]-DZ_inWidth<=444.8)
+  		 {
+  		 	ClosestStrip = (int) (floor(((z_real-Z0[layer]-DZ_inWidth-423.36)/pitchC6[13]))+0.5+35*32);
+  		 }	 
+  	   }
+	   
+	 else if(layer==1)
+	   { // this for "Z4" layers, i.e. measuring phi
 	     phi_real = phi + ((G4RandGauss::shoot(0,sigma_td))/cos(theta_L)-(sqrt(x*x+y*y)-R[layer]+hStrip2Det)*tan(theta_L))/R[layer]; // the sign of the 2nd term (Lorentz angle) should be a "-" as the B field is along +z and the MM are convex (and electrons are negatively charged)
-	     ClosestStrip = (int) (floor(((R[layer]/pitchZ)*(phi_real-phiij+Pi/Nsector-DZ_inLength/R[layer]))+0.5));
+	     ClosestStrip = (int) (floor(((R[layer]/pitchZ4)*(phi_real-phiij+Pi/Nsector - (Inactivtheta[layer]/2.)*Pi/180. - DZ_inLength/R[layer]))+0.5));
 	   }
+  	 else if(layer==2)
+  	   { // this for "Z5" layers, i.e. measuring phi
+  	     phi_real = phi + ((G4RandGauss::shoot(0,sigma_td))/cos(theta_L)-(sqrt(x*x+y*y)-R[layer]+hStrip2Det)*tan(theta_L))/R[layer]; // the sign of the 2nd term (Lorentz angle) should be a "-" as the B field is along +z and the MM are convex (and electrons are negatively charged)
+  	     ClosestStrip = (int) (floor(((R[layer]/pitchZ5)*(phi_real-phiij+Pi/Nsector - (Inactivtheta[layer]/2.)*Pi/180. - DZ_inLength/R[layer]))+0.5));
+  	   }
+     else if(layer==4)
+       { // this for "Z6" layers, i.e. measuring phi
+    	phi_real = phi + ((G4RandGauss::shoot(0,sigma_td))/cos(theta_L)-(sqrt(x*x+y*y)-R[layer]+hStrip2Det)*tan(theta_L))/R[layer]; // the sign of the 2nd term (Lorentz angle) should be a "-" as the B field is along +z and the MM are convex (and electrons are negatively charged)
+    	ClosestStrip = (int) (floor(((R[layer]/pitchZ6)*(phi_real-phiij+Pi/Nsector - (Inactivtheta[layer]/2.)*Pi/180. - DZ_inLength/R[layer]))+0.5));
+      }
+	  
+	   
 	 if(ClosestStrip>=0 && ClosestStrip<=Nstrips[layer] && z>=Z0[layer]+DZ_inWidth && z<=Z0[layer]+DZ[layer]-DZ_inWidth && phi>=phiij-Pi/Nsector+DZ_inLength/R[layer] && phi<=phiij+Pi/Nsector-DZ_inLength/R[layer])
 	   { // strip is in the acceptance, check if new strip or not
 	     for(int istrip=0;istrip< (int) (strip_id.size()/2);istrip++)

--- a/hitprocess/clas12/micromegas/bmt_strip.h
+++ b/hitprocess/clas12/micromegas/bmt_strip.h
@@ -15,7 +15,6 @@ using namespace std;
 class bmt_strip
 {
 	public:
-  double pitchZ, pitchC; // pitch for Z and C detectors
 		int Nsector;
 		double Pi;
 
@@ -25,6 +24,26 @@ class bmt_strip
 		vector<double> R;        // radii of layers
 		vector<double> MidTile;  // mid angle of the sector
 		vector<int> Nstrips;     // number of strips in each detector
+		
+		double interStripZ; // interstrip for CRnZ
+		double interStripC; // interstrip for CRnC
+		double pitchZ4;  // pitch for Z4
+		double pitchZ5;  // pitch for Z5
+		double pitchZ6;  // pitch for Z6
+		vector<double> pitchC4;  // pitch for C4
+		vector<double> pitchC5;  // pitch for C5
+		vector<double> pitchC6;  // pitch for C6
+		
+		vector<double> Inactivtheta; // dead angle because of mecanics
+		double DZ_inLength; // size of the band of dead zones all around in the length of the card
+		double DZ_inWidth; // size of the band of dead zones all around in the width of the card
+		double DZ4_inLength; // size of the band of dead zones all around in the length of the card (for CR4Z)
+		double DZ4_inWidth; // size of the band of dead zones all around in the width of the card (for CR4C)
+		double DZ5_inLength; // size of the band of dead zones all around in the length of the card (for CR5Z)
+		double DZ5_inWidth; // size of the band of dead zones all around in the width of the card (for CR5C)
+		double DZ6_inLength; // size of the band of dead zones all around in the length of the card (for CR6Z)
+		double DZ6_inWidth; // size of the band of dead zones all around in the width of the card (for CR6C)
+		
 
 		double hDrift;           // Size of the drift gap
 		double hStrip2Det;       // distance between strips and the middle of the conversion gap (~half the drift gap)
@@ -35,8 +54,6 @@ class bmt_strip
 		int Nel;                 // number of electrons (Nt) for a given hit
 		double z_real, phi_real; // z and phi of the hit after transverse diffusion
 
-		double DZ_inLength;      // size of the band of dead zones all around in the length of the card
-		double DZ_inWidth;       // size of the band of dead zones all around in the width of the card
 
 		double x,y,z;            // z of the track is redefined in FindCard. Units are microns - input are millimiters 
 		void fill_infos(); 

--- a/hitprocess/clas12/micromegas/fmt_strip.cc
+++ b/hitprocess/clas12/micromegas/fmt_strip.cc
@@ -9,38 +9,61 @@ void fmt_strip::fill_infos()
   // all dimensions are in mm
   
   Pi  = 3.14159265358;
-  interlayer      = (0.5+0.1+0.015+0.128+0.030+2.500)*2.; // distance between 2 layers of a superlayer
+  //  interlayer      = (0.5+0.1+0.015+0.128+0.030+2.500)*2.; // distance between 2 layers of a superlayer // not usefull anymore, 07/27/2015 (Frederic Georges)
   //  intersuperlayer = 20.0;      // distance between 2 superlayers
-  intersuperlayer = 21.0;      // distance between 2 superlayers // modified on 5/20/2015 to match new geometry (R.De Vita)
-  pitch           = 0.500;     // pitch of the strips
+  //  intersuperlayer = 21.0;      // distance between 2 superlayers // modified on 5/20/2015 to match new geometry (R.De Vita)
+  intersuperlayer = 10.5;      // distance between 2 superlayers // modified on 7/27/2015 to match new geometry (Frederic Georges)
+  //  pitch           = 0.500;     // pitch of the strips
+  pitch           = 0.525;     // pitch of the strips // modified on 7/27/2015 to match new geometry (Frederic Georges)
   hDrift          = 5.0;
-  hStrip2Det      = hDrift/2.;
+  //hStrip2Det      = hDrift/2.;
   sigma_td_max    = 0.01; // very small transverse diffusion because of B field
   w_i             = 25.0;
   
-  R_min = 12.900;
-  R_max = 215.0;  // outer radius of strip part
+  //R_min = 12.900;
+  //R_max = 215.0;  // outer radius of strip part
+  R_min = 45.500;   // modified on 7/27/2015 to match new geometry (Frederic Georges)
+  R_max = 185.400;  // outer radius of strip part // modified on 7/27/2015 to match new geometry (Frederic Georges)
   //  Z_1stlayer = 295.-0.5-0.1-0.015-0.128-0.030-2.500; // z position of the 1st layer (middle of the drift gap)
-  Z_1stlayer = 305.25-0.5-0.1-0.015-0.128-0.030-2.500; // z position of the 1st layer (middle of the drift gap) // modified on 5/20/2015 to match new geometry (R.De Vita)
+  //Z_1stlayer = 305.25-0.5-0.1-0.015-0.128-0.030-2.500; // z position of the 1st layer (middle of the drift gap) // modified on 5/20/2015 to match new geometry (R.De Vita)
+  Z_1stlayer = 305.250-0.005-0.200-2.000-0.200-0.005-0.050-0.020-0.128-0.030-2.500; // z position of the 1st layer (middle of the drift gap) // modified on 7/27/2015 to match new geometry (Frederic Georges)
   
   // z of the upstream part of the layer
+  /*
   Z0.push_back(Z_1stlayer);
   Z0.push_back(Z0[0]+interlayer);
   Z0.push_back(Z_1stlayer+intersuperlayer);
   Z0.push_back(Z0[2]+interlayer);
   Z0.push_back(Z_1stlayer+2.*intersuperlayer);
   Z0.push_back(Z0[4]+interlayer);
+  */
+  // modified on 7/27/2015 to match new geometry (Frederic Georges)
+  Z0.push_back(Z_1stlayer);
+  Z0.push_back(Z0[0]+intersuperlayer);
+  Z0.push_back(Z0[1]+intersuperlayer);
+  Z0.push_back(Z0[2]+intersuperlayer);
+  Z0.push_back(Z0[3]+intersuperlayer);
+  Z0.push_back(Z0[4]+intersuperlayer);
   
   // angles of each layer
+  /*
   alpha.push_back(0);
   alpha.push_back(Pi/2.);
   alpha.push_back(Pi/3.);
   alpha.push_back(Pi/2+Pi/3.);
   alpha.push_back(2.*Pi/3.);
   alpha.push_back(2.*Pi/3+Pi/2.);
+  */
+  // modified on 7/27/2015 to match new geometry (Frederic Georges)
+  alpha.push_back(19.*Pi/180.);
+  alpha.push_back(alpha[0]+Pi/3.);
+  alpha.push_back(alpha[0]+2.*Pi/3.);
+  alpha.push_back(alpha[0]+Pi);
+  alpha.push_back(alpha[0]+4.*Pi/3.);
+  alpha.push_back(alpha[0]+5.*Pi/3.);
   
   // Number of strips and pixels
-  N_str = (int) floor(2.*R_max/pitch);
+  N_str = 1024; //16 connectors * 64 strips = 1024 strips for each fmt
 }
 
 vector<double> fmt_strip::FindStrip(int layer, int sector, double x, double y, double z, double Edep)
@@ -59,10 +82,23 @@ vector<double> fmt_strip::FindStrip(int layer, int sector, double x, double y, d
     {
       for(int iel=0;iel<Nel;iel++)
 	{ // loop over (total) electrons
-	  u_real = (double) (G4RandGauss::shoot(y*cos(alpha[layer])-x*sin(alpha[layer]),sigma_td));
-	  ClosestStrip = (int) (floor((u_real+R_max)/pitch));
+	  x_real = (double) (G4RandGauss::shoot(x*cos(alpha[layer])+y*sin(alpha[layer]),sigma_td));
+	  y_real = (double) (G4RandGauss::shoot(y*cos(alpha[layer])-x*sin(alpha[layer]),sigma_td));
 	  
-	  if(sqrt(x*x+y*y)<R_max && sqrt(x*x+y*y)>R_min && ClosestStrip>=0 && ClosestStrip<=N_str)
+	  if(y_real > -84.1 && y_real < 84.1 && x_real < 0){ // R_max - 3*64*0.525 - 0.5 = 84.1;
+		ClosestStrip = (int) (floor((84.1-y_real)/pitch)+1);
+	  	}
+	  else if(y_real < -84.1 && y_real > -184.9){ // R_max - 3*64*0.525 - 0.5 = 84.1; R_max - 0.5 = 184.9
+	  	ClosestStrip = (int) (floor((-y_real-84.1)/pitch)+1) + 320; // 5*64 = 320
+		}
+	  else if(y_real > -84.1 && y_real < 84.1 && x_real > 0){ // R_max - 3*64*0.525 - 0.5 = 84.1;
+		ClosestStrip = (int) (floor((y_real+84.1)/pitch)+1) + 512;	 // (5+3)*64 = 512
+		}
+	  else if(y_real > 84.1 && y_real < 184.9){ // R_max - 3*64*0.525 - 0.5 = 84.1; R_max - 0.5 = 184.9
+		  ClosestStrip = (int) (floor((y_real-84.1)/pitch)+1) + 832; // (5+3+5)*64 = 832
+		}
+	
+	  if(sqrt(x*x+y*y)<R_max && sqrt(x*x+y*y)>R_min && ClosestStrip>=1 && ClosestStrip<=N_str)
 	    { // strip is in the acceptance (~)
 	      for(int istrip=0;istrip< (int) (strip_id.size()/2);istrip++)
 		{

--- a/hitprocess/clas12/micromegas/fmt_strip.h
+++ b/hitprocess/clas12/micromegas/fmt_strip.h
@@ -9,8 +9,8 @@ class fmt_strip
 
 		double interlayer;       // distance between 2 layers of a superlayer
 		double intersuperlayer;  // distance between 2 superlayers
-		double R_max;         // outer radius of strip part
-		double R_min;         // inner radius of strip part
+		double R_max;            // outer radius of strip part
+		double R_min;            // inner radius of strip part
 
 		double Z_1stlayer;       // z position of the 1st layer
 
@@ -23,7 +23,8 @@ class fmt_strip
 		double sigma_td;         // current value of the transverse diffusion
 		double w_i;              // mean ionization potential
 		int Nel;                 // number of electrons (Nt) for a given hit
-		double u_real; // u of the hit after transverse diffusion
+		double y_real; 			 // y position of the hit after transverse diffusion
+		double x_real;			 // x position of the hit after transverse diffusion
 		void fill_infos();
 
 		vector<double> FindStrip( int layer, int sector, double x, double y, double z, double Edep);   // Strip Finding Routine


### PR DESCRIPTION
Updates the way the stripsIDs are computed during the simulation of an event for micromegas detectors fmt and bmt, due to new geometry.