### PR TITLE
Update ftof_hitprocess.cc

### DIFF
--- a/hitprocess/clas12/ftof_hitprocess.cc
+++ b/hitprocess/clas12/ftof_hitprocess.cc
@@ -136,13 +136,19 @@ map<string, double> ftof_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 	double attLeft  = exp(-dLeft/cm/attLength);
 	double attRight = exp(-dRight/cm/attLength);
 
+	// gain factor to simulate PMT gain matching algorithm
+	// i.e.- L,R PMTs are not gain matched to each other, but adjusted so geometeric mean sqrt(L*R)
+	// is independent of counter length
+	double gainLeft  = sqrt(attLeft*attRight);
+	double gainRight = gainLeft;
+	
 	// multiple of MIP energy attenuated
 	double eneL = (tInfos.eTot/ftc.dEdxMIP)*attLeft;
 	double eneR = (tInfos.eTot/ftc.dEdxMIP)*attRight;
 	
 	// attenuated energy, converted in counts
-	double adcl = ftc.countsForAMinimumIonizing[sector-1][panel-1][0][paddle-1]*eneL;
-	double adcr = ftc.countsForAMinimumIonizing[sector-1][panel-1][1][paddle-1]*eneR;
+	double adcl = ftc.countsForAMinimumIonizing[sector-1][panel-1][0][paddle-1]*eneL/gainLeft;
+	double adcr = ftc.countsForAMinimumIonizing[sector-1][panel-1][1][paddle-1]*eneR/gainRight;
 
 	// timewalk depends on adc values
 	double timeWalkLeft  = ftc.twlk_A0[sector-1][panel-1][0][paddle-1]/(1 + ftc.twlk_A1[sector-1][panel-1][0][paddle-1]*sqrt(adcl));


### PR DESCRIPTION
Added factors gainLeft,gainRight to simulate PMT gain matching algorithm for FTOF.

L,R PMTs are not gain matched to each other, but adjusted so geometric mean sqrt(LR) is independent of counter length.  This results in an overall factor of exp(-0.5 L/lambda) (L=bar length, lambda=attenuation length) which is built into the HV adjustment, in addition to gain balancing.  This factor was missing from GEMC.
  
First plot below shows GEMC result for muon MIP geom. mean of FTOF L and R panel 1A before (left) and after (right).
Second plot show comparison of GEMC and real data from forward carriage for 1A.
Third plot shows same comparison for 1B.
![gemc-gm-1](https://cloud.githubusercontent.com/assets/10797791/9749898/4c992f8a-565f-11e5-9f96-1a11a5f8cd1f.png)
![gemc-data-1a](https://cloud.githubusercontent.com/assets/10797791/9749899/502918d6-565f-11e5-8608-4b28ab394395.png)
![gemc-data-1b](https://cloud.githubusercontent.com/assets/10797791/9749909/5e71d734-565f-11e5-9c62-ff37e91bafc1.png)
