### PR TITLE
CCDB Functionality in CTOF,FTOF

### DIFF
--- a/hitprocess/clas12/ctof_hitprocess.cc
+++ b/hitprocess/clas12/ctof_hitprocess.cc
@@ -1,3 +1,12 @@
+// G4 headers
+#include "G4Poisson.hh"
+#include "Randomize.hh"
+
+#include <CCDB/Calibration.h>
+#include <CCDB/Model/Assignment.h>
+#include <CCDB/CalibrationGenerator.h>
+using namespace ccdb;
+
 // gemc headers
 #include "ctof_hitprocess.h"
 
@@ -5,11 +14,125 @@
 #include "CLHEP/Units/PhysicalConstants.h"
 using namespace CLHEP;
 
+static ctofConstants initializeCTOFConstants(int runno)
+{
+	ctofConstants ctc;
+
+	cout<<"Entering initializeCTOF"<<endl;
+
+	// do not initialize at the beginning, only after the end of the first event,
+	// with the proper run number coming from options or run table
+	if(runno == -1) return ctc;
+
+	ctc.runNo      = runno;
+	ctc.date       = "2015-11-29";
+	ctc.connection = "mysql://clas12reader@clasdb.jlab.org/clas12";
+	ctc.variation  = "default";
+
+	ctc.npaddles   = 48;
+	ctc.thick      = 3.0;
+	
+	ctc.dEdxMIP       = 1.956;  // muons in polyvinyltoluene
+	ctc.dEMIP         = ctc.thick*ctc.dEdxMIP;
+	ctc.pmtPEYld      = 243;
+	ctc.pmtQE         = 0.27;
+	ctc.pmtDynodeGain = 4.0; 
+        ctc.pmtDynodeK    = 0.5; 
+	ctc.pmtFactor     = sqrt(1-ctc.pmtQE+(ctc.pmtDynodeK*ctc.pmtDynodeGain+1)/(ctc.pmtDynodeGain-1));
+	ctc.tdcLSB        = 41.6667;
+	
+	cout<<"CTOF:Setting time resolution"<<endl;
+
+	for(int c=1; c<ctc.npaddles+1;c++)
+	{
+	  ctc.tres.push_back(60.);
+	}
+	
+	
+	int isec,ilay,istr;
+	
+	vector<vector<double> > data;
+	
+	auto_ptr<Calibration> calib(CalibrationGenerator::CreateCalibration(ctc.connection));
+        cout<<"Connecting to "<<ctc.connection<<"/calibration/ctof"<<endl;
+	
+	cout<<"CTOF:Getting attenuation"<<endl;
+	sprintf(ctc.database,"/calibration/ctof/attenuation:%d",ctc.runNo);
+	data.clear(); calib->GetCalib(data,ctc.database);	
+	for(unsigned row = 0; row < data.size(); row++)
+	{
+	  isec   = data[row][0]; ilay   = data[row][1]; istr   = data[row][2];
+	  ctc.attlen[isec-1][ilay-1][0].push_back(data[row][3]);
+	  ctc.attlen[isec-1][ilay-1][1].push_back(data[row][4]);
+	}
+	
+        cout<<"CTOF:Getting effective_velocity"<<endl;
+	sprintf(ctc.database,"/calibration/ctof/effective_velocity:%d",ctc.runNo);
+	data.clear(); calib->GetCalib(data,ctc.database);	
+	for(unsigned row = 0; row < data.size(); row++)
+	{
+	  isec   = data[row][0]; ilay   = data[row][1]; istr   = data[row][2];
+	  ctc.veff[isec-1][ilay-1][0].push_back(data[row][3]);
+	  ctc.veff[isec-1][ilay-1][1].push_back(data[row][4]);
+	}
+
+	cout<<"CTOF:Getting status"<<endl;
+	sprintf(ctc.database,"/calibration/ctof/status:%d",ctc.runNo);
+	data.clear() ; calib->GetCalib(data,ctc.database);
+	for(unsigned row = 0; row < data.size(); row++)
+	{
+	  isec   = data[row][0]; ilay   = data[row][1]; istr   = data[row][2];
+	  ctc.status[isec-1][ilay-1][0].push_back(data[row][3]);
+	  ctc.status[isec-1][ilay-1][1].push_back(data[row][4]);
+	}
+
+	cout<<"CTOF:Getting gain_balance"<<endl;
+	sprintf(ctc.database,"/calibration/ctof/gain_balance:%d",ctc.runNo);
+	data.clear() ; calib->GetCalib(data,ctc.database);	
+	for(unsigned row = 0; row < data.size(); row++)
+	{
+	  isec   = data[row][0]; ilay   = data[row][1]; istr   = data[row][2];
+	  ctc.countsForMIP[isec-1][ilay-1][0].push_back(data[row][3]);
+	  ctc.countsForMIP[isec-1][ilay-1][1].push_back(data[row][4]);
+	}
+
+	/* For future use in HitProcess
+	cout<<"Getting time_walk"<<endl;
+	sprintf(ctc.database,"/calibration/ctof/time_walk:%d",ctc.runNo);
+	data.clear() ; calib->GetCalib(data,ctc.database);	
+	for(unsigned row = 0; row < data.size(); row++)
+	{
+	  isec   = data[row][0]; ilay   = data[row][1]; istr   = data[row][2];
+	  ctc.twlk[isec-1][ilay-1][0].push_back(data[row][3]);
+	  ctc.twlk[isec-1][ilay-1][1].push_back(data[row][4]);
+	  ctc.twlk[isec-1][ilay-1][2].push_back(data[row][5]);
+	  ctc.twlk[isec-1][ilay-1][3].push_back(data[row][6]);
+	  ctc.twlk[isec-1][ilay-1][4].push_back(data[row][7]);
+	  ctc.twlk[isec-1][ilay-1][5].push_back(data[row][8]);
+	}
+	*/
+	
+	return ctc;
+}
+
+void ctof_HitProcess::initWithRunNumber(int runno)
+{
+	if(ctc.runNo != runno)
+	{
+		cout << " > Initializing " << HCname << " digitization for run number " << runno << endl;
+		ctc = initializeCTOFConstants(runno);
+		ctc.runNo = runno;
+	}
+}
+
+
 map<string, double> ctof_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 {
 	map<string, double> dgtz;
 	vector<identifier> identity = aHit->GetId();
-	
+
+	int sector = 1;
+	int panel  = 1;
 	int paddle = identity[0].id;
 	
 	// Get the paddle length: in ctof paddles are boxes, the length is the y dimension
@@ -17,24 +140,67 @@ map<string, double> ctof_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 	
 	trueInfos tInfos(aHit);
 	
-	// Distances from left, right
-	double dLeft  = length + tInfos.ly;
-	double dRight = length - tInfos.ly;
+	// Distances from upstream, downstream
+	double dUp = length + tInfos.ly;
+	double dDn = length - tInfos.ly;
 	
-	// dummy formulas for now, parameters could come from DB
-	int ADCL = (int) (100*tInfos.eTot*exp(-dLeft/length/2  ));
-	int ADCR = (int) (100*tInfos.eTot*exp(-dRight/length/2 ));
+	// attenuation length
+	double attlenUp = ctc.attlen[sector-1][panel-1][0][paddle-1];
+	double attlenDn = ctc.attlen[sector-1][panel-1][1][paddle-1];
+
+	// attenuation factor
+	double attUp  = exp(-dUp/cm/attlenUp);
+	double attDn  = exp(-dDn/cm/attlenDn);
+
+	// Attenuated light at PMT
+	double eneUp = tInfos.eTot*attUp;
+	double eneDn = tInfos.eTot*attDn;
+
+	double adcu = 0.;
+	double adcd = 0.;
+        double tdcu = 0.;
+	double tdcd = 0.;
+
+	// Fluctuate the light measured by the PMT with
+	// Poisson distribution for emitted photoelectrons
+	// Treat Up and Dn separately, in case nphe=0
+
+	double npheUp = G4Poisson(eneUp*ctc.pmtPEYld);
+	eneUp = npheUp/ctc.pmtPEYld;
+
+	if (eneUp>0) {
+	                 adcu = eneUp*ctc.countsForMIP[sector-1][panel-1][0][paddle-1]/ctc.dEMIP;
+	 //double            A = ctc.twlk[sector-1][panel-1][0][paddle-1];
+         //double            B = ctc.twlk[sector-1][panel-1][1][paddle-1];
+         //double            C = ctc.twlk[sector-1][panel-1][2][paddle-1];
+	 //double   timeWalkUp = A/(B+C*sqrt(adcu));
+	  double    timeWalkUp = 0.;
+	  double          tUpU = tInfos.time + dUp/ctc.veff[sector-1][panel-1][0][paddle-1]/cm + timeWalkUp;
+	  double           tUp = G4RandGauss::shoot(tUpU,  sqrt(2)*ctc.tres[paddle-1]*1e-3);
+	                  tdcu = tUp*ctc.tdcLSB;
+	}  
 	
-	// speed of light is 30 cm/s
-	int TDCL = (int) (100*(tInfos.time/ns + dLeft/cm/30.0));
-	int TDCR = (int) (100*(tInfos.time/ns + dRight/cm/30.0));
+	double npheDn = G4Poisson(eneDn*ctc.pmtPEYld);
+	eneDn = npheDn/ctc.pmtPEYld;
+
+	if (eneDn>0) {
+	                 adcd = eneDn*ctc.countsForMIP[sector-1][panel-1][1][paddle-1]/ctc.dEMIP;
+	 //double            A = ctc.twlk[sector-1][panel-1][3][paddle-1];
+         //double            B = ctc.twlk[sector-1][panel-1][4][paddle-1];
+         //double            C = ctc.twlk[sector-1][panel-1][5][paddle-1];
+	 //double   timeWalkDn = A/(B+C*sqrt(adcd));
+	  double    timeWalkDn = 0.;
+	  double          tDnU = tInfos.time + dDn/ctc.veff[sector-1][panel-1][1][paddle-1]/cm + timeWalkDn;
+	  double           tDn = G4RandGauss::shoot(tDnU,  sqrt(2)*ctc.tres[paddle-1]*1e-3);
+	                  tdcd = tDn*ctc.tdcLSB;
+	}  
 	
 	dgtz["hitn"]   = hitn;
 	dgtz["paddle"] = paddle;
-	dgtz["ADCL"]   = ADCL;
-	dgtz["ADCR"]   = ADCR;
-	dgtz["TDCL"]   = TDCL;
-	dgtz["TDCR"]   = TDCR;
+	dgtz["ADCL"]   = (int) adcu;
+	dgtz["ADCR"]   = (int) adcd;
+	dgtz["TDCL"]   = (int) tdcu;
+	dgtz["TDCR"]   = (int) tdcd;
 	
 	return dgtz;
 }
@@ -53,3 +219,5 @@ map< string, vector <int> >  ctof_HitProcess :: multiDgt(MHit* aHit, int hitn)
 	return MH;
 }
 
+// this static function will be loaded first thing by the executable
+ctofConstants ctof_HitProcess::ctc = initializeCTOFConstants(-1);

--- a/hitprocess/clas12/ctof_hitprocess.h
+++ b/hitprocess/clas12/ctof_hitprocess.h
@@ -4,11 +4,59 @@
 // gemc headers
 #include "HitProcess.h"
 
+class ctofConstants
+{
+	public:
+
+		// Database parameters
+		int    runNo;	
+		string variation;
+		string date;
+		string connection;
+		char   database[80];
+
+		// For paddle dependent constants read from CCDB
+		// Array [1][1][2] -> sector,panel,UD
+		
+		// status:
+		//	0 - fully functioning
+		//	1 - noADC
+		//	2 - noTDC
+		//	3 - noADC, noTDC (PMT is dead)
+		//      5 - any other reconstruction problem
+		vector<int> status[1][1][2];
+	
+		// veff: effective velocity
+		vector<double> veff[1][1][2];
+	
+		// attlen: attenuation length 
+		vector<double> attlen[1][1][2];
+	
+		// countsForMIP: Desired ADC channel for MIP peak calibration
+		vector<double> countsForMIP[1][1][2];
+	
+		// twlk: Time walk correction, 3 constants each for L and R
+		vector<double> twlk[1][1][6];
+	
+		// tres: Gaussian sigma for smearing time resolution
+		vector<double> tres;
+		
+		int    npaddles;     // Number of paddles.
+		int    thick;        // Thickness of paddles (cm).
+		double dEdxMIP;      // Nominal MIP specific energy loss (MeV/gm/cm2).
+		double dEMIP;        // Nominal MIP energy loss (MeV).
+	
+		double pmtPEYld;      // Photoelectron yield (p.e./MeV)
+		double pmtQE;         // Quantum efficiency of PMT
+		double pmtDynodeGain; // PMT dynode gain
+		double pmtDynodeK;    // PMT dynode secondary emission statistics factor: K=0 (Poisson) K=1 (exponential) 
+		double pmtFactor;     // Contribution to FWHM from PMT statistical fluctuations. 
+		double tdcLSB;        // Conversion from ns to TDC channel.
+};
+
 // Class definition
 /// \class ctof_HitProcess
-/// <b> Ceontral Time of Flight Hit Process Routine</b>\n\n
-/// The Calibration Constants are:\n
-/// - VEF is the effective velocity of propogation in the scintillator
+/// <b> Central Time of Flight Hit Process Routine</b>\n\n
 
 class ctof_HitProcess : public HitProcess
 {
@@ -16,6 +64,11 @@ class ctof_HitProcess : public HitProcess
 	
 		~ctof_HitProcess(){;}
 	
+		// constants initialized with initWithRunNumber
+		static ctofConstants ctc;
+		
+		void initWithRunNumber(int runno);
+
 		// - integrateDgt: returns digitized information integrated over the hit
 		map<string, double> integrateDgt(MHit*, int);
 				

--- a/hitprocess/clas12/ec_hitprocess.h
+++ b/hitprocess/clas12/ec_hitprocess.h
@@ -10,19 +10,27 @@ class ecConstants
 {
 	public:
 		// runNo is mandatory variable to keep track of run number changes
-		int runNo;
+		int    runNo;
 		string variation;
 		string date;
 		string connection;
 		char   database[80];
+
+		// For strip dependent constants read from CCDB
+		// Array [6][9][3] -> sector,layer,view sector=1-6 layer=1-3 (PCAL) 4-6 (ECinner) 7-9 (ECouter) view=1-3 (U,V,W)
+
+		//attlen: attenuation length
+		vector<double> attlen[6][9][3];
 		
-		double NSTRIPS;                 // Number of strips
-		vector<double> attlen[6][9][3];         // Attenuation Length (mm)
-		double attl;
-		double TDC_time_to_evio;        // Conversion from time (ns) to EVIO TDC format
-		double ADC_MeV_to_evio;         // Conversion from energy (MeV) to EVIO FADC250 format
-		double PE_yld;                  // Number of p.e. divided by the energy deposited in MeV. See EC NIM paper table 1.
-		double veff;                    // Effective velocity of scintillator light (mm/ns)
+		double NSTRIPS;             // Number of strips
+		double TDC_time_to_evio;    // Conversion from time (ns) to EVIO TDC format
+		double ADC_MeV_to_evio;     // Conversion from energy (MeV) to EVIO FADC250 format
+		double veff;                // Effective velocity of scintillator light (mm/ns)
+		double pmtPEYld;            // Number of p.e. divided by the energy deposited in MeV. See EC NIM paper table 1.
+		double pmtQE;               // Quantum efficiency of PMT
+		double pmtDynodeGain;       // PMT dynode gain
+		double pmtDynodeK;          // PMT dynode secondary emission statistics factor: K=0 (Poisson) K=1 (exponential) 
+		double pmtFactor;           // Contribution to FWHM from PMT statistical fluctuations.		  
 };
 
 

--- a/hitprocess/clas12/ftof_hitprocess.h
+++ b/hitprocess/clas12/ftof_hitprocess.h
@@ -9,60 +9,57 @@ class ftofConstants
 {
 	public:
 
-		// database
+		// Database parameters
 		int    runNo;	
 		string variation;
 		string date;
 		string connection;
-		char database[80];
+		char   database[80];
 
-	
-		// There are 3 FTOF panels, 6 sectors so the constants are organized in
-		// 6 + 3 dimensional arrays + 2 for Left and Right
-	
-		// number of paddles in each panel, in order p1a, p1b, p2
-		int npaddles[3];
-		int thick[3];
-	
+		// For paddle dependent constants read from CCDB
+		// Array [6][3][2] -> sector,panel,LR
+		
 		// status:
 		//	0 - fully functioning
 		//	1 - noADC
 		//	2 - noTDC
-		//	3 - noADC, noTDC(PMTisdead)
-		//  5 - any other reconstruction problem
+		//	3 - noADC, noTDC (PMT is dead)
+		//      5 - any other reconstruction problem
 		vector<int> status[6][3][2];
 	
-		// effective velocity
+		// veff: effective velocity
 		vector<double> veff[6][3][2];
 	
-		// attenuation length comes from a linear parameterization
-		// based on the counter length in cm
-		// depends on the panel
+		// attlen: attenuation length 
 		vector<double> attlen[6][3][2];
 	
-		// dEdxMIP: dEdx for muon MIP, dEMIP: MIP energy for paddle
-		double dEdxMIP;
-		double dEMIP[3];
-	
-		// minimum ionizing calibration peak
+		// countsForMIP: Desired ADC channel for MIP peak calibration
 		vector<double> countsForMIP[6][3][2];
 	
-		// time walk correction is parameterized with two coefficients
+		// twlk: Time walk correction, 3 constants each for L and R
 		vector<double> twlk[6][3][6];
 	
-		// time resolution parameterized as sigma0^2 + sigma1^2/N
-		// where N is number of photoelectrons reaching the PTMS
-		double sigma0[3], sigma1[3];
-		double nphePerMevReachingPMT;
+		// tres: Gaussian sigma for smearing time resolution
+		vector<double> tres[3];
+		
+		int    npaddles[3];  // Number of paddles for Panel 1A, 1B and 2.
+		int    thick[3];     // Thickness of paddles (cm) for Panel 1A, 1B and 2.
+		double dEdxMIP;      // Nominal MIP specific energy loss (MeV/gm/cm2)
+		double dEMIP[3];     // Nominal MIP energy loss (MeV) for Panel 1A, 1B and 2.
 	
+		double pmtPEYld;      // Photoelectron yield (p.e./MeV)
+		double pmtQE;         // Quantum efficiency of PMT
+		double pmtDynodeGain; // PMT dynode gain
+		double pmtDynodeK;    // PMT dynode secondary emission statistics factor: K=0 (Poisson) K=1 (exponential) 
+		double pmtFactor;     // Contribution to FWHM from PMT statistical fluctuations. 
+		double tdcLSB;        // Conversion from ns to TDC channel.
 };
 
 
 // Class definition
 /// \class ftof_HitProcess
 /// <b> Forward Time of Flight Hit Process Routine</b>\n\n
-/// The Calibration Constants are:\n
-/// - VEF is the effective velocity of propogation in the scintillator
+
 class ftof_HitProcess : public HitProcess
 {
 	public:

--- a/hitprocess/clas12/pcal_hitprocess.cc
+++ b/hitprocess/clas12/pcal_hitprocess.cc
@@ -18,8 +18,7 @@ static pcConstants initializePCConstants(int runno)
 	// do not initialize at the beginning, only after the end of the first event,
 	// with the proper run number coming from options or run table
 	if(runno == -1) return pcc;
-	
-	
+		
 	int isec,ilay,istr;
 	
 	// database
@@ -28,14 +27,22 @@ static pcConstants initializePCConstants(int runno)
 	pcc.connection = "mysql://clas12reader@clasdb.jlab.org/clas12";
 	pcc.variation  = "default";
 	
-	pcc.attl                = 3760.;  // Attenuation Length (mm)
 	pcc.TDC_time_to_evio    = 1000.;  // Currently EVIO banks receive time from rol2.c in ps (raw counts x 24 ps/chan. for both V1190/1290), so convert ns to ps.
 	pcc.ADC_MeV_to_evio     = 10.  ;  // MIP based calibration is nominally 10 channels/MeV
-	pcc.PE_yld              = 11.5 ;  // Number of p.e. divided by the energy deposited in MeV. See EC NIM paper table 1.
 	pcc.veff                = 160. ;  // Effective velocity of scintillator light (mm/ns)
+	pcc.pmtPEYld            = 11.5 ; // Number of p.e. divided by the energy deposited in MeV. See EC NIM paper table 1.
+	pcc.pmtQE               = 0.27 ; 
+	pcc.pmtDynodeGain       = 4.0  ; 
+        pcc.pmtDynodeK          = 0.5  ; // K=0 (Poisson) K=1(exponential)	vector<vector<double> > data;
+	//  Fluctuations in PMT gain distributed using Gaussian with
+	//  sigma=1/SNR where SNR = sqrt[(1-QE+(k*del+1)/(del-1))/npe] del = dynode gain k=0-1
+	//  Adapted from G-75 (pg. 169) and and G-111 (pg. 174) from RCA PMT Handbook.
+	//  Factor k for dynode statistics can range from k=0 (Poisson) to k=1 (exponential).
+	//  Note: GSIM sigma was incorrect (used 1/sigma for sigma).
+	pcc.pmtFactor           = sqrt(1-pcc.pmtQE+(pcc.pmtDynodeK*pcc.pmtDynodeGain+1)/(pcc.pmtDynodeGain-1));
 
 	vector<vector<double> > data;
-	auto_ptr<Calibration> calib(CalibrationGenerator::CreateCalibration(pcc.connection));
+        auto_ptr<Calibration> calib(CalibrationGenerator::CreateCalibration(pcc.connection));
 	
 	sprintf(pcc.database,"/calibration/ec/attenuation:%d",pcc.runNo);
 	data.clear(); calib->GetCalib(data,pcc.database);
@@ -120,20 +127,20 @@ map<string, double> pcal_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 	int TDC = 0;
 	
 	// simulate the adc value.
-	if (tInfos.eTot > 0)
-	{
-		double PC_npe = G4Poisson(Etota*pcc.PE_yld); //number of photoelectrons
-																	//  Fluctuations in PMT gain distributed using Gaussian with
-																	//  sigma SNR = sqrt(ngamma)/sqrt(del/del-1) del = dynode gain = 3 (From RCA PMT Handbook) p. 169)
-																	//  algorithm, values, and comment above taken from gsim.
-		double sigma = sqrt(PC_npe)/1.22;
-		double PC_MeV = G4RandGauss::shoot(PC_npe,sigma)*pcc.ADC_MeV_to_evio/pcc.PE_yld;
-		if (PC_MeV <= 0) PC_MeV=0.0; // guard against weird, rare events.
-		ADC = (int) PC_MeV;
+	if (Etota > 0) {
+	  double PC_npe = G4Poisson(Etota*pcc.pmtPEYld); //number of photoelectrons
+	  if (PC_npe>0) {
+	    double sigma = pcc.pmtFactor/sqrt(PC_npe);
+	    double PC_MeV = G4RandGauss::shoot(PC_npe,sigma)*pcc.ADC_MeV_to_evio/pcc.pmtPEYld;
+	    if (PC_MeV>0) {
+	      ADC = (int) PC_MeV;
+	      TDC = (int) ((tInfos.time+Ttota/tInfos.nsteps)*pcc.TDC_time_to_evio);
+	    }
+	  }
 	}
 	
-	// simulate the tdc.
-	TDC = (int) ((tInfos.time+Ttota/tInfos.nsteps)*pcc.TDC_time_to_evio);
+	// EVIO banks record time with offset determined by position of data in capture window.  On forward carriage this is currently
+	// around 1.4 us.  This offset is omitted in the simulation.
 	
 	dgtz["hitn"]   = hitn;
 	dgtz["sector"] = sector;

--- a/hitprocess/clas12/pcal_hitprocess.h
+++ b/hitprocess/clas12/pcal_hitprocess.h
@@ -18,11 +18,15 @@ class pcConstants
 		char   database[80];
 	
 		vector<double> attlen[6][9][3];  // Attenuation Length (mm)
-		double attl;
+
 		double TDC_time_to_evio;     // Conversion from time (ns) to EVIO TDC format
 		double ADC_MeV_to_evio;      // Conversion from energy (MeV) to EVIO FADC250 format
-		double PE_yld;               // Number of p.e. divided by the energy deposited in MeV.
 		double veff;                 // Effective velocity of scintillator light (mm/ns)
+		double pmtPEYld;             // Number of p.e. divided by the energy deposited in MeV.
+		double pmtQE;
+		double pmtDynodeGain;
+		double pmtDynodeK;
+		double pmtFactor;
 };
 
 // Class definition


### PR DESCRIPTION
ctof_hitprocess.cc now processes CCDB constants in accordance with Dan Carman's documentation.
Coding is similar to ftof_hitprocess.cc.  Time-walk code is implemented but commented out for future use in case corrections to CFD timings are added to CCDB.  

ftof_hitprocess.cc now follows D. Carman's documentation for FTOF, including smearing of ADC and TDC.

Bug fixed in gaussian smearing of single and several photoelectron response in pcal_hitprocess.cc and ec_hitprocess.cc.  This is important mainly when light is attenuated to near the single photoelectron levels.