### PR TITLE
Neutron cosmic rays generator + new fields in cosmic rays steering card

### DIFF
--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -61,7 +61,10 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		double cminp, cmaxp, cMom;        ///< minimum and maximum cosmic ray momentum
 		G4ThreeVector cosmicTarget;       ///< Location of area of interest for cosmic rays
 		double cosmicRadius;              ///< radius of area of interest for cosmic rays
-	
+		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder) 
+		string cosmicParticle;            ///< type of cosmic ray particle
+		string muonDecay;                 ///< type of muon decay
+
 		// Generators Input Files
 		ifstream  gif;                    ///< Generator Input File
 		ifstream  bgif;                   ///< Background Generator Input File
@@ -97,8 +100,9 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		G4ParticleGun* particleGun;
 		void setBeam();
 	
-		double cosmicBeam(double, double);
-	
+		double cosmicMuBeam(double, double);
+		double cosmicNeutBeam(double, double);
+
 };
 
 #endif


### PR DESCRIPTION
1) new generator for neutron cosmic rays
- The vertical distribution of cosmic neutrons is described by 
j(E) dE ~ E^(-gamma)dE with gamma =  2.95 +- 10
(from a fit of data by several experiments by Ashton et al. (Cosmic rays at ground level (1973), updated by Nature 256, 387 (1975), see picture in attachment). 
- The zenith angle dependence is given by:
I(theta) = I(0)*cos^n(theta) with theta = 3.5 +- 1.2
(from Heidbreder et al., J. Geophys. Pres. 76, 2905 (1971))
![neutronverticalspectrum](https://cloud.githubusercontent.com/assets/6739214/14430566/61c3d746-0002-11e6-9d00-0525db17b666.jpg)


2) new fields in cosmic ray steering data cards:
- two more fields in COSMICRAYS:
  type of cosmic rays particle: muon || neutron (default: muon is selected)
  type of decay mode for muons: default || radiative (default: standard muon decay)
- one more field in COSMICAREA:
  type of surface for cosmic rays generation: sph (sphere) || cyl (default: sphere)
  the cyindr height is taken as twice the radius valua