### PR TITLE
Muon decay

### DIFF
--- a/physics/PhysicsList.h
+++ b/physics/PhysicsList.h
@@ -6,6 +6,7 @@
 
 // geant4 headers
 #include "G4VModularPhysicsList.hh"
+#include "G4DecayWithSpin.hh"
 
 // c++ headers
 #include <string>
@@ -63,6 +64,7 @@ private:
 	G4VPhysicsConstructor*  g4EMPhysics;
 	G4VPhysicsConstructor*  g4ParticleList;
 	vector<G4VPhysicsConstructor*>  g4HadronicPhysics;
+	G4DecayWithSpin*        theDecayProcess;
 
 	// build the geant4 physics
 	void cookPhysics();

--- a/sensitivity/sensitiveDetector.cc
+++ b/sensitivity/sensitiveDetector.cc
@@ -315,7 +315,8 @@ int sensitiveDetector::processID(string procName)
 	if(procName == "hPairProd")        return 23;
 	if(procName == "tInelastic")       return 24;
 	if(procName == "kaon-Inelastic")   return 25;
-	
+	if(procName == "DecayWithSpin")    return 26;
+
 	if(procName == "na")            return 90;
 	
 	cout << " process name " << procName << " not catalogued." << endl;

--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -61,7 +61,10 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		double cminp, cmaxp, cMom;        ///< minimum and maximum cosmic ray momentum
 		G4ThreeVector cosmicTarget;       ///< Location of area of interest for cosmic rays
 		double cosmicRadius;              ///< radius of area of interest for cosmic rays
-	
+		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder) 
+		string cosmicParticle;            ///< type of cosmic ray particle
+		string muonDecay;                 ///< type of muon decay
+
 		// Generators Input Files
 		ifstream  gif;                    ///< Generator Input File
 		ifstream  bgif;                   ///< Background Generator Input File
@@ -97,8 +100,9 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		G4ParticleGun* particleGun;
 		void setBeam();
 	
-		double cosmicBeam(double, double);
-	
+		double cosmicMuBeam(double, double);
+		double cosmicNeutBeam(double, double);
+
 };
 
 #endif


### PR DESCRIPTION
Changes to include muon radiative decay table, to be selected by COSMICRAYS data card - the default is muon standard decay (with spin).
Usage: default || radiative
"radiative" selects the DecayWithSpin radiative process provided by GEANT4 (forced decay with BR = 100%). 
"default" means standard V-A muon decay (including muon spin) with proper BR for the radiative/non radiative channels.

In sensitiveDetector.cc DecayWithSpin has been added to the process list.