### PR TITLE
cosmic rays generation inside a cylinder volume

### DIFF
--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -61,6 +61,7 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		double cminp, cmaxp, cMom;        ///< minimum and maximum cosmic ray momentum
 		G4ThreeVector cosmicTarget;       ///< Location of area of interest for cosmic rays
 		double cosmicRadius;              ///< radius of area of interest for cosmic rays
+		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder) 
 	
 		// Generators Input Files
 		ifstream  gif;                    ///< Generator Input File


### PR DESCRIPTION
The geometry parameters (x,y,z of the center, radiius) are steered by the COSMICAREA card, the height is set to half the radius. The choice of the cylindric geometry is steered from the last field (#5) of the COSMICAREA card: 
- default: " " || "sph" || "sphere" for a sphere
- "cyl" for a cylinder