### PR TITLE
generator for neutron cosmic rays

### DIFF
--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -61,7 +61,8 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		double cminp, cmaxp, cMom;        ///< minimum and maximum cosmic ray momentum
 		G4ThreeVector cosmicTarget;       ///< Location of area of interest for cosmic rays
 		double cosmicRadius;              ///< radius of area of interest for cosmic rays
-		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder) 
+		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder)
+		string cosmicParticle;            ///< type of cosmic ray particle (muon || neutron)
 	
 		// Generators Input Files
 		ifstream  gif;                    ///< Generator Input File
@@ -98,7 +99,8 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		G4ParticleGun* particleGun;
 		void setBeam();
 	
-		double cosmicBeam(double, double);
+		double cosmicMuBeam(double, double);
+		double cosmicNeutBeam(double, double);
 	
 };
 


### PR DESCRIPTION
Generation of neutron cosmic rays:

- The vertical distribution of cosmic neutrons is described by
 j(E) dE ~ E^(-gamma)dE with gamma = 2.95 +- 10 
(from a fit of data by several experiments by Ashton et al. (Cosmic rays at ground level (1973), updated by Nature 256, 387 (1975), see picture). 

![neutronverticalspectrum](https://cloud.githubusercontent.com/assets/6739214/15079839/24ad4992-13bb-11e6-9a12-c1dd5ecf686f.jpg)

- The zenith angle dependence is given by: 
I(theta) = I(0)*cos^n(theta) with theta = 3.5 +- 1.2 
(from Heidbreder et al., J. Geophys. Pres. 76, 2905 (1971)) 

Neutrons are selected by the 4th field in the COSMICRAYS data card, corresponding to the type of cosmic ray particle: muon || neutron. Default (null string): muon is selected.
