### PR TITLE
inclusion of muon radiative decay, steered by COSMICRAYS data card

### DIFF
--- a/physics/PhysicsList.cc
+++ b/physics/PhysicsList.cc
@@ -22,6 +22,11 @@ using namespace std;
 #include "G4Electron.hh"
 #include "G4Positron.hh"
 #include "G4Proton.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4ParticleTypes.hh"
+#include "G4ParticleTable.hh"
+#include "G4DecayTable.hh"                                                     
+#include "G4ProcessTable.hh"
 
 // geant4 physics headers
 #include "G4DecayPhysics.hh"
@@ -38,6 +43,9 @@ using namespace std;
 #include "G4IonBinaryCascadePhysics.hh"
 #include "G4IonPhysics.hh"
 #include "G4NeutronTrackingCut.hh"
+#include "G4MuonRadiativeDecayChannelWithSpin.hh"
+#include "G4MuonDecayChannelWithSpin.hh"
+#include "G4DecayWithSpin.hh"
 
 // CLHEP units
 #include "CLHEP/Units/PhysicalConstants.h"
@@ -329,13 +337,61 @@ void PhysicsList::cookPhysics()
 
 void PhysicsList::ConstructParticle()
 {
+	string cosmics =  gemcOpt.optMap["COSMICRAYS"].args;
+	vector<string> csettings = get_info(cosmics, string(",\""));
+	string decayType = "default";
+	string particleType;
+	int len = csettings.size();
+	if(csettings[0] == "default"){
+	  if(len>4){
+	    particleType = csettings[3];
+	    decayType = csettings[4];
+	  }
+	}else{
+	  if(len>6){
+	    particleType = csettings[5];
+	    decayType = csettings[6];
+	  }
+	}
+	// warn if muon radiative decay is selected but the simulated
+        // cosmic rays is not a muon
+	if(decayType=="radiative" && particleType!="muon") 
+	  cout << "!!! Check COSMICRAYS data card, muon radiative decay required but no muon being simulated " << endl;
+	
 	g4ParticleList->ConstructParticle();
+	G4Electron::ElectronDefinition();
+	G4Positron::PositronDefinition();
+	G4NeutrinoE::NeutrinoEDefinition();
+	G4AntiNeutrinoE::AntiNeutrinoEDefinition();
+	G4MuonPlus::MuonPlusDefinition();
+	G4MuonMinus::MuonMinusDefinition();
+	G4NeutrinoMu::NeutrinoMuDefinition();
+	G4AntiNeutrinoMu::AntiNeutrinoMuDefinition();
+	
+	G4DecayTable* MuonPlusDecayTable = new G4DecayTable();
+	G4DecayTable* MuonMinusDecayTable = new G4DecayTable();
+	
+	if(decayType == "radiative"){
+	  MuonPlusDecayTable -> Insert(new G4MuonRadiativeDecayChannelWithSpin("mu+",1.00));
+	  MuonMinusDecayTable -> Insert(new G4MuonRadiativeDecayChannelWithSpin("mu-",1.00));
+	}else{ // default
+	  MuonPlusDecayTable -> Insert(new G4MuonDecayChannelWithSpin("mu+",0.986));
+	  MuonPlusDecayTable -> Insert(new G4MuonRadiativeDecayChannelWithSpin("mu+",0.014));
+	  MuonMinusDecayTable -> Insert(new G4MuonDecayChannelWithSpin("mu-",0.986));
+	  MuonMinusDecayTable -> Insert(new G4MuonRadiativeDecayChannelWithSpin("mu-",1.00));
+  }
+	G4MuonPlus::MuonPlusDefinition() -> SetDecayTable(MuonPlusDecayTable);
+	G4MuonMinus::MuonMinusDefinition() -> SetDecayTable(MuonMinusDecayTable);
 }
 
 
 void PhysicsList::ConstructProcess()
 {
 	AddTransportation();
+	theDecayProcess = new G4DecayWithSpin();
+	G4ProcessTable* processTable = G4ProcessTable::GetProcessTable();
+	G4VProcess* decay;
+
 	if(g4EMPhysics)
 		g4EMPhysics->ConstructProcess();
 	
@@ -351,9 +407,11 @@ void PhysicsList::ConstructProcess()
 
 	while( (*theParticleIterator)() )
 	{
+
 		G4ParticleDefinition* particle = theParticleIterator->value();
 		G4ProcessManager*     pmanager = particle->GetProcessManager();
-	    string                pname    = particle->GetParticleName();
+		string                pname    = particle->GetParticleName();
+		decay = processTable->FindProcess("Decay",particle);      
 	
 		// Adding Step Limiter
 		if ((!particle->IsShortLived()) && (particle->GetPDGCharge() != 0.0) && (pname != "chargedgeantino"))
@@ -364,10 +422,14 @@ void PhysicsList::ConstructProcess()
 			pmanager->AddProcess(new G4StepLimiter,       -1,-1,3);
 		}
 
+		if (theDecayProcess->IsApplicable(*particle)) {
+		  if(decay) pmanager->RemoveProcess(decay);
+		  pmanager->AddProcess(theDecayProcess);
+		  pmanager ->SetProcessOrdering(theDecayProcess, idxPostStep);
+		  pmanager->SetProcessOrderingToLast(theDecayProcess, idxAtRest);
+		}
 	}
-
 }
-
 
 
 

--- a/physics/PhysicsList.h
+++ b/physics/PhysicsList.h
@@ -6,6 +6,7 @@
 
 // geant4 headers
 #include "G4VModularPhysicsList.hh"
+#include "G4DecayWithSpin.hh"
 
 // c++ headers
 #include <string>
@@ -63,6 +64,7 @@ private:
 	G4VPhysicsConstructor*  g4EMPhysics;
 	G4VPhysicsConstructor*  g4ParticleList;
 	vector<G4VPhysicsConstructor*>  g4HadronicPhysics;
+	G4DecayWithSpin*        theDecayProcess;
 
 	// build the geant4 physics
 	void cookPhysics();

--- a/sensitivity/sensitiveDetector.cc
+++ b/sensitivity/sensitiveDetector.cc
@@ -321,7 +321,8 @@ int sensitiveDetector::processID(string procName)
 	if(procName == "lambdaInelastic")  return 29;
 	if(procName == "sigma-Inelastic")  return 30;
 	if(procName == "hBrems")           return 31;
-	
+	if(procName == "DecayWithSpin")    return 32;
+
 	if(procName == "na")            return 90;
 	
 	cout << " process name " << procName << " not catalogued." << endl;

--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -79,6 +79,8 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 			cout << hd_msg << " Cosmic Radius :" << cosmicRadius/cm << " cm " << endl;
 			cout << hd_msg << " Cosmic Surface Type: " << cosmicGeo << endl;
 			cout << hd_msg << " Cosmic Particle Type: " << cosmicParticle << endl;
+			if(cosmicParticle == "muon")
+			  cout << hd_msg << " Muon decay Type: " << muonDecay << endl;
 		}
 	}
 	
@@ -766,8 +768,12 @@ void MPrimaryGeneratorAction::setBeam()
 				
 				// model is valid only starting at 1 GeV for now
 				if(cminp < 1) cminp = 1;
+				
+				// select cosmic ray particle from data card
+				muonDecay = "default with spin";
 				if(len>3){
 				  cosmicParticle = csettings[3];
+				  if(len>4 && csettings[4]=="radiative") muonDecay = "radiative only with spin";
 				}else{
 				  cosmicParticle = "muon";
 				}
@@ -784,12 +790,14 @@ void MPrimaryGeneratorAction::setBeam()
 				// model is valid only starting at 1 GeV for now
 				if(cminp < 1) cminp = 1;
 				
+				// select cosmic ray particle from data card
+				muonDecay = "default with spin";
 				if(len>5){
 				  cosmicParticle = csettings[5];
+				  if(len>6 && csettings[6] =="radiative") muonDecay = "radiative only with spin";
 				}else{
 				  cosmicParticle = "muon";
 				}
-
 			}
 		}
 	}

--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -63,6 +63,7 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		double cosmicRadius;              ///< radius of area of interest for cosmic rays
 		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder)
 		string cosmicParticle;            ///< type of cosmic ray particle (muon || neutron)
+		string muonDecay;                 ///< type of muon decay
 	
 		// Generators Input Files
 		ifstream  gif;                    ///< Generator Input File


### PR DESCRIPTION
radiative decay mode for muons included, steered by the field in the COSMICRAYS data card following the particle type.  Possible values: default || radiative 
- "default" corresponds to muon decay including the radiative component with its branching ratio (~1.5%)
- "radiative" forces the radiative muon decay with B.R. 100%.
Note that with the standard e.m. physics list no decay is foreseen for the muon. 