### PR TITLE
include radiative muon decay with spin, BR=100%

### DIFF
--- a/physics/PhysicsList.h
+++ b/physics/PhysicsList.h
@@ -6,6 +6,7 @@
 
 // geant4 headers
 #include "G4VModularPhysicsList.hh"
+#include "G4DecayWithSpin.hh"
 
 // c++ headers
 #include <string>
@@ -58,11 +59,11 @@ private:
 	
 	vector<G4String> g4HadronicList;
 	vector<G4String> g4EMList;
-	
-	
+		
 	G4VPhysicsConstructor*  g4EMPhysics;
 	G4VPhysicsConstructor*  g4ParticleList;
 	vector<G4VPhysicsConstructor*>  g4HadronicPhysics;
+	G4DecayWithSpin*        theDecayProcess;
 
 	// build the geant4 physics
 	void cookPhysics();

--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -27,7 +27,8 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 	cosmics        = gemcOpt->optMap["COSMICRAYS"].args;
 	string cArea   = gemcOpt->optMap["COSMICAREA"].args;
 	GEN_VERBOSITY  = gemcOpt->optMap["GEN_VERBOSITY"].arg;
-	
+	muonDecay = 0;
+	muonDecay      = gemcOpt->optMap["FORCE_MUON_RADIATIVE_DECAY"].arg;
 	
 	particleTable = G4ParticleTable::GetParticleTable();
 	
@@ -79,6 +80,8 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 			cout << hd_msg << " Cosmic Radius :" << cosmicRadius/cm << " cm " << endl;
 			cout << hd_msg << " Cosmic Surface Type: " << cosmicGeo << endl;
 			cout << hd_msg << " Cosmic Particle Type: " << cosmicParticle << endl;
+			if(cosmicParticle == "muon" && muonDecay==1)
+			  cout << hd_msg << " radiative muon decay BR=100%" << endl;
 		}
 	}
 	
@@ -766,6 +769,8 @@ void MPrimaryGeneratorAction::setBeam()
 				
 				// model is valid only starting at 1 GeV for now
 				if(cminp < 1) cminp = 1;
+				
+				// select cosmic ray particle from data card
 				if(len>3){
 				  cosmicParticle = csettings[3];
 				}else{
@@ -784,12 +789,12 @@ void MPrimaryGeneratorAction::setBeam()
 				// model is valid only starting at 1 GeV for now
 				if(cminp < 1) cminp = 1;
 				
+				// select cosmic ray particle from data card
 				if(len>5){
 				  cosmicParticle = csettings[5];
 				}else{
 				  cosmicParticle = "muon";
 				}
-
 			}
 		}
 	}

--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -63,6 +63,7 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		double cosmicRadius;              ///< radius of area of interest for cosmic rays
 		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder)
 		string cosmicParticle;            ///< type of cosmic ray particle (muon || neutron)
+		int muonDecay;                  ///< type of muon decay
 	
 		// Generators Input Files
 		ifstream  gif;                    ///< Generator Input File

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -120,7 +120,11 @@ void goptions::setGoptions()
 	optMap["COSMICAREA"].type = 1;
 	optMap["COSMICAREA"].ctgr = "generator";
 	
-
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].arg = 0;
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].help = "Force muon radiative decay";
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].name = "Muon rad decay BR 100%";
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].type = 0;
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].ctgr = "generator";
 	
 	// Luminosity Beam
 	optMap["LUMI_P"].args  = "e-, 11*GeV, 0*deg, 0*deg";
@@ -607,7 +611,6 @@ void goptions::setGoptions()
 	optMap["PHYS_VERBOSITY"].name = "Physics List Verbosity";
 	optMap["PHYS_VERBOSITY"].type = 0;
 	optMap["PHYS_VERBOSITY"].ctgr = "physics";
-	
 	
 	// by default set max field step to 1 cm. Notice: it has to be greater than the min!
 	optMap["MAX_FIELD_STEP"].arg =  0;


### PR DESCRIPTION
include radiative muon decay with spin, BR=100%, steered by  FORCE_MUON_RADIATIVE_DECAY option. Option values:

Default = 0: 
- BR(mu->e+nu+antinu) = 98.6%
- BR(mu->e+nu+antinu+gamma) = 1.4%
- muon spin neglected (GEANT4 default, standard em model default)

Force radiative decay = 1 (or different from zero): 
- BR(mu-> e+nu+antinu+gamma) = 100%
- muon spin (V-A) decay included