### PR TITLE
Muon radiative decay, BR = 100%

### DIFF
--- a/physics/PhysicsList.cc
+++ b/physics/PhysicsList.cc
@@ -22,9 +22,6 @@ using namespace std;
 #include "G4Electron.hh"
 #include "G4Positron.hh"
 #include "G4Proton.hh"
-#include "G4ParticleDefinition.hh"
-#include "G4ParticleTypes.hh"
-#include "G4ParticleTable.hh"
 #include "G4DecayTable.hh"                                                     
 #include "G4ProcessTable.hh"
 
@@ -45,7 +42,6 @@ using namespace std;
 #include "G4NeutronTrackingCut.hh"
 #include "G4MuonRadiativeDecayChannelWithSpin.hh"
 #include "G4MuonDecayChannelWithSpin.hh"
-#include "G4DecayWithSpin.hh"
 
 // CLHEP units
 #include "CLHEP/Units/PhysicalConstants.h"
@@ -356,7 +352,6 @@ void PhysicsList::ConstructParticle()
 void PhysicsList::ConstructProcess()
 {
 	AddTransportation();
-	theDecayProcess = new G4DecayWithSpin();
 	G4ProcessTable* processTable = G4ProcessTable::GetProcessTable();
 	G4VProcess* decay;
 
@@ -367,8 +362,6 @@ void PhysicsList::ConstructProcess()
 	
 	for(size_t i=0; i<g4HadronicPhysics.size(); i++)
 		g4HadronicPhysics[i]->ConstructProcess();
-
-
 
 	// PhysicsList contains theParticleIterator
 	theParticleIterator->reset();
@@ -390,6 +383,7 @@ void PhysicsList::ConstructProcess()
 		}
 
 		if(muonRadDecay){
+		  theDecayProcess = new G4DecayWithSpin();
 		  decay = processTable->FindProcess("Decay",particle);      
 		  if (theDecayProcess->IsApplicable(*particle)) {
 		    if(decay) pmanager->RemoveProcess(decay);

--- a/physics/PhysicsList.cc
+++ b/physics/PhysicsList.cc
@@ -337,31 +337,10 @@ void PhysicsList::cookPhysics()
 
 void PhysicsList::ConstructParticle()
 {
-        int muonRadDecay = 0;
+        muonRadDecay = 0;
         muonRadDecay = gemcOpt.optMap["FORCE_MUON_RADIATIVE_DECAY"].arg;
-	string cosmics =  gemcOpt.optMap["COSMICRAYS"].args;
-	vector<string> csettings = get_info(cosmics, string(",\""));
-	string particleType;
-	int len = csettings.size();
-	if(csettings[0] == "default"){
-	  if(len>4) particleType = csettings[3];
-	}else{
-	  if(len>6) particleType = csettings[5];
-	}
-	// warn if muon radiative decay is selected but the simulated
-        // cosmic rays is not a muon
-	if(muonRadDecay && particleType!="muon") 
-	  cout << "!!! Check COSMICRAYS data card, muon radiative decay required but no muon being simulated " << endl;
-	
+
 	g4ParticleList->ConstructParticle();
-	G4Electron::ElectronDefinition();
-	G4Positron::PositronDefinition();
-	G4NeutrinoE::NeutrinoEDefinition();
-	G4AntiNeutrinoE::AntiNeutrinoEDefinition();
-	G4MuonPlus::MuonPlusDefinition();
-	G4MuonMinus::MuonMinusDefinition();
-	G4NeutrinoMu::NeutrinoMuDefinition();
-	G4AntiNeutrinoMu::AntiNeutrinoMuDefinition();
 	
 	if(muonRadDecay){
 	  G4DecayTable* MuonPlusDecayTable = new G4DecayTable();
@@ -400,7 +379,6 @@ void PhysicsList::ConstructProcess()
 		G4ParticleDefinition* particle = theParticleIterator->value();
 		G4ProcessManager*     pmanager = particle->GetProcessManager();
 		string                pname    = particle->GetParticleName();
-		decay = processTable->FindProcess("Decay",particle);      
 	
 		// Adding Step Limiter
 		if ((!particle->IsShortLived()) && (particle->GetPDGCharge() != 0.0) && (pname != "chargedgeantino"))
@@ -411,12 +389,16 @@ void PhysicsList::ConstructProcess()
 			pmanager->AddProcess(new G4StepLimiter,       -1,-1,3);
 		}
 
-		if (theDecayProcess->IsApplicable(*particle)) {
-		  if(decay) pmanager->RemoveProcess(decay);
-		  pmanager->AddProcess(theDecayProcess);
-		  pmanager ->SetProcessOrdering(theDecayProcess, idxPostStep);
-		  pmanager->SetProcessOrderingToLast(theDecayProcess, idxAtRest);
+		if(muonRadDecay){
+		  decay = processTable->FindProcess("Decay",particle);      
+		  if (theDecayProcess->IsApplicable(*particle)) {
+		    if(decay) pmanager->RemoveProcess(decay);
+		    pmanager->AddProcess(theDecayProcess);
+		    pmanager->SetProcessOrdering(theDecayProcess, idxPostStep);
+		    pmanager->SetProcessOrderingToLast(theDecayProcess, idxAtRest);
+		  }
 		}
+		  
 	}
 }
 

--- a/physics/PhysicsList.h
+++ b/physics/PhysicsList.h
@@ -56,6 +56,7 @@ private:
 	string EMPhys;
 	string opticalPhys;
 	string HPPhys;
+	int    muonRadDecay;
 	
 	vector<G4String> g4HadronicList;
 	vector<G4String> g4EMList;

--- a/physics/PhysicsList.h
+++ b/physics/PhysicsList.h
@@ -6,6 +6,7 @@
 
 // geant4 headers
 #include "G4VModularPhysicsList.hh"
+#include "G4DecayWithSpin.hh"
 
 // c++ headers
 #include <string>
@@ -58,11 +59,11 @@ private:
 	
 	vector<G4String> g4HadronicList;
 	vector<G4String> g4EMList;
-	
-	
+		
 	G4VPhysicsConstructor*  g4EMPhysics;
 	G4VPhysicsConstructor*  g4ParticleList;
 	vector<G4VPhysicsConstructor*>  g4HadronicPhysics;
+	G4DecayWithSpin*        theDecayProcess;
 
 	// build the geant4 physics
 	void cookPhysics();

--- a/sensitivity/sensitiveDetector.cc
+++ b/sensitivity/sensitiveDetector.cc
@@ -321,7 +321,8 @@ int sensitiveDetector::processID(string procName)
 	if(procName == "lambdaInelastic")  return 29;
 	if(procName == "sigma-Inelastic")  return 30;
 	if(procName == "hBrems")           return 31;
-	
+	if(procName == "DecayWithSpin")    return 32;
+
 	if(procName == "na")            return 90;
 	
 	cout << " process name " << procName << " not catalogued." << endl;

--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -27,7 +27,8 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 	cosmics        = gemcOpt->optMap["COSMICRAYS"].args;
 	string cArea   = gemcOpt->optMap["COSMICAREA"].args;
 	GEN_VERBOSITY  = gemcOpt->optMap["GEN_VERBOSITY"].arg;
-	
+	muonDecay = 0;
+	muonDecay      = gemcOpt->optMap["FORCE_MUON_RADIATIVE_DECAY"].arg;
 	
 	particleTable = G4ParticleTable::GetParticleTable();
 	
@@ -79,6 +80,8 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 			cout << hd_msg << " Cosmic Radius :" << cosmicRadius/cm << " cm " << endl;
 			cout << hd_msg << " Cosmic Surface Type: " << cosmicGeo << endl;
 			cout << hd_msg << " Cosmic Particle Type: " << cosmicParticle << endl;
+			if(cosmicParticle == "muon" && muonDecay==1)
+			  cout << hd_msg << " radiative muon decay BR=100%" << endl;
 		}
 	}
 	
@@ -766,6 +769,8 @@ void MPrimaryGeneratorAction::setBeam()
 				
 				// model is valid only starting at 1 GeV for now
 				if(cminp < 1) cminp = 1;
+				
+				// select cosmic ray particle from data card
 				if(len>3){
 				  cosmicParticle = csettings[3];
 				}else{
@@ -784,12 +789,12 @@ void MPrimaryGeneratorAction::setBeam()
 				// model is valid only starting at 1 GeV for now
 				if(cminp < 1) cminp = 1;
 				
+				// select cosmic ray particle from data card
 				if(len>5){
 				  cosmicParticle = csettings[5];
 				}else{
 				  cosmicParticle = "muon";
 				}
-
 			}
 		}
 	}

--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -27,8 +27,6 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 	cosmics        = gemcOpt->optMap["COSMICRAYS"].args;
 	string cArea   = gemcOpt->optMap["COSMICAREA"].args;
 	GEN_VERBOSITY  = gemcOpt->optMap["GEN_VERBOSITY"].arg;
-	muonDecay = 0;
-	muonDecay      = gemcOpt->optMap["FORCE_MUON_RADIATIVE_DECAY"].arg;
 	
 	particleTable = G4ParticleTable::GetParticleTable();
 	
@@ -80,8 +78,6 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 			cout << hd_msg << " Cosmic Radius :" << cosmicRadius/cm << " cm " << endl;
 			cout << hd_msg << " Cosmic Surface Type: " << cosmicGeo << endl;
 			cout << hd_msg << " Cosmic Particle Type: " << cosmicParticle << endl;
-			if(cosmicParticle == "muon" && muonDecay==1)
-			  cout << hd_msg << " radiative muon decay BR=100%" << endl;
 		}
 	}
 	

--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -63,7 +63,6 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		double cosmicRadius;              ///< radius of area of interest for cosmic rays
 		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder)
 		string cosmicParticle;            ///< type of cosmic ray particle (muon || neutron)
-		int muonDecay;                  ///< type of muon decay
 	
 		// Generators Input Files
 		ifstream  gif;                    ///< Generator Input File

--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -63,6 +63,7 @@ class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 		double cosmicRadius;              ///< radius of area of interest for cosmic rays
 		string cosmicGeo;                 ///< type of surface for cosmic ray generation (sphere || cylinder)
 		string cosmicParticle;            ///< type of cosmic ray particle (muon || neutron)
+		int muonDecay;                  ///< type of muon decay
 	
 		// Generators Input Files
 		ifstream  gif;                    ///< Generator Input File

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -120,7 +120,11 @@ void goptions::setGoptions()
 	optMap["COSMICAREA"].type = 1;
 	optMap["COSMICAREA"].ctgr = "generator";
 	
-
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].arg = 0;
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].help = "Force muon radiative decay";
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].name = "Muon rad decay BR 100%";
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].type = 0;
+	optMap["FORCE_MUON_RADIATIVE_DECAY"].ctgr = "generator";
 	
 	// Luminosity Beam
 	optMap["LUMI_P"].args  = "e-, 11*GeV, 0*deg, 0*deg";
@@ -607,7 +611,6 @@ void goptions::setGoptions()
 	optMap["PHYS_VERBOSITY"].name = "Physics List Verbosity";
 	optMap["PHYS_VERBOSITY"].type = 0;
 	optMap["PHYS_VERBOSITY"].ctgr = "physics";
-	
 	
 	// by default set max field step to 1 cm. Notice: it has to be greater than the min!
 	optMap["MAX_FIELD_STEP"].arg =  0;


### PR DESCRIPTION
include radiative muon decay with spin, BR=100%, steered by FORCE_MUON_RADIATIVE_DECAY option. Option values:

Default = 0:
- BR(mu->e+nu+antinu) = 98.6%
- BR(mu->e+nu+antinu+gamma) = 1.4%
- muon spin neglected (GEANT4 default, standard em model default)

Force radiative decay = 1 (or different from zero):
-  BR(mu-> e+nu+antinu+gamma) = 100%
-  muon spin (V-A) decay included