### PR TITLE
Update of the fmt stripfinder and hitprocess

### DIFF
--- a/hitprocess/clas12/micromegas/fmt_strip.cc
+++ b/hitprocess/clas12/micromegas/fmt_strip.cc
@@ -12,7 +12,7 @@ void fmt_strip::fill_infos()
 	//  interlayer      = (0.5+0.1+0.015+0.128+0.030+2.500)*2.; // distance between 2 layers of a superlayer // not usefull anymore, 07/27/2015 (Frederic Georges)
 	//  intersuperlayer = 20.0;      // distance between 2 superlayers
 	//  intersuperlayer = 21.0;      // distance between 2 superlayers // modified on 5/20/2015 to match new geometry (R.De Vita)
-	intersuperlayer = 10.5;      // distance between 2 superlayers // modified on 7/27/2015 to match new geometry (Frederic Georges)
+	intersuperlayer = 11.9;      // distance between 2 superlayers // modified on 7/27/2015 to match new geometry (Frederic Georges)
 	//  pitch           = 0.500;     // pitch of the strips
 	pitch           = 0.525;     // pitch of the strips // modified on 7/27/2015 to match new geometry (Frederic Georges)
 	hDrift          = 5.0;
@@ -20,14 +20,12 @@ void fmt_strip::fill_infos()
 	sigma_td_max    = 0.01; // very small transverse diffusion because of B field
 	w_i             = 25.0;
 
-	//R_min = 12.900;
-	//R_max = 215.0;  // outer radius of strip part
-	R_min = 45.500;   // modified on 7/27/2015 to match new geometry (Frederic Georges)
-	R_max = 185.400;  // outer radius of strip part // modified on 7/27/2015 to match new geometry (Frederic Georges)
+	R_min = 42.575;   // modified on 7/27/2015 to match new geometry (Frederic Georges)
+  // outer radius of strip part // modified on 7/27/2015 to match new geometry (Frederic Georges)
 	//  Z_1stlayer = 295.-0.5-0.1-0.015-0.128-0.030-2.500; // z position of the 1st layer (middle of the drift gap)
 	//Z_1stlayer = 305.25-0.5-0.1-0.015-0.128-0.030-2.500; // z position of the 1st layer (middle of the drift gap) // modified on 5/20/2015 to match new geometry (R.De Vita)
-	Z_1stlayer = 305.250-0.005-0.200-2.000-0.200-0.005-0.050-0.020-0.128-0.030-2.500; // z position of the 1st layer (middle of the drift gap) // modified on 7/27/2015 to match new geometry (Frederic Georges)
-
+	//Z_1stlayer = 305.250-0.005-0.200-2.000-0.200-0.005-0.050-0.020-0.128-0.030-2.500; // z position of the 1st layer (middle of the drift gap) // modified on 7/27/2015 to match new geometry (Frederic Georges)
+	Z_1stlayer = 300.3;
 	// z of the upstream part of the layer
 	/*
   Z0.push_back(Z_1stlayer);
@@ -41,7 +39,7 @@ void fmt_strip::fill_infos()
 	Z0.push_back(Z_1stlayer);
 	Z0.push_back(Z0[0]+intersuperlayer);
 	Z0.push_back(Z0[1]+intersuperlayer);
-	Z0.push_back(Z0[2]+intersuperlayer);
+	Z0.push_back(Z0[2]+intersuperlayer+2.0); //modified on 2/22/2017 to match new geometry (Maxime Defurne)
 	Z0.push_back(Z0[3]+intersuperlayer);
 	Z0.push_back(Z0[4]+intersuperlayer);
 
@@ -64,6 +62,13 @@ void fmt_strip::fill_infos()
 
 	// Number of strips and pixels
 	N_str = 1024; //16 connectors * 64 strips = 1024 strips for each fmt
+	N_halfstr = 320; //number of bottom strips in the central part
+	N_sidestr = (N_str-2*N_halfstr)/2; //number of strips one side
+	y_central = N_halfstr*pitch/2.; // Y-limit of the central part
+	nb_sigma=4;
+
+	R_max = pitch*(N_halfstr+2*N_sidestr)/2.;
+	
 }
 
 vector<double> fmt_strip::FindStrip(int layer, int sector, double x, double y, double z, double Edep)
@@ -74,65 +79,152 @@ vector<double> fmt_strip::FindStrip(int layer, int sector, double x, double y, d
 	vector<double> strip_id;
 	// number of electrons (Nt)
 	Nel = (int) (1e6*Edep/w_i);
-	if(z-Z0[layer]>0.5001*hDrift || z-Z0[layer]<-0.5001*hDrift) cout << "Warning! z position of the FMT hit is not in the sensitive volume: " << z-Z0[layer]<< endl;
 	sigma_td = sigma_td_max* sqrt((z-Z0[layer])/hDrift); // expression without Lorentz angle
+	//if(z>Z0[layer]+7.697 || z<Z0[layer]+2.697) cout << "Warning! z position of the FMT hit is not in the sensitive volume: " << z <<" for bottom of gas at "<<Z0[layer]<< endl;
 
+	
 	int ClosestStrip=0;
-	if(Nel>0)
+	int clust_size=nb_sigma*sigma_td/pitch+1; //+1 might be a little bit conservative
+	if(Nel>0&&sqrt(x*x+y*y)<R_max && sqrt(x*x+y*y)>R_min)
 	{
-		for(int iel=0;iel<Nel;iel++)
-		{ // loop over (total) electrons
-	  x_real = (double) (G4RandGauss::shoot(x*cos(alpha[layer])+y*sin(alpha[layer]),sigma_td));
-	  y_real = (double) (G4RandGauss::shoot(y*cos(alpha[layer])-x*sin(alpha[layer]),sigma_td));
+	
+	  x_real = x*cos(alpha[layer])+y*sin(alpha[layer]);
+	  y_real = y*cos(alpha[layer])-x*sin(alpha[layer]);
+	  
+	  if(y_real>-y_central && y_real < y_central){ 
+	    if (x_real<=0) ClosestStrip = (int) (floor((y_central-y_real)/pitch)+1);
+	    if (x_real>0) ClosestStrip = (int) (floor((y_real+y_central)/pitch)+1) + N_halfstr+N_sidestr;
+	  }
+	  else if(y_real <= -y_central && y_real > -R_max){ 
+	    ClosestStrip = (int) (floor((y_central-y_real)/pitch)+1); 
+	  }
+	  else if(y_real >= y_central && y_real < R_max){ 
+	    ClosestStrip = (int) (floor((y_real+y_central)/pitch)+1) + N_halfstr+N_sidestr;  
+	  }
+	 
+	  int strip_num=ClosestStrip;// To look around closeststrip
+	  double weight=Weight_td(ClosestStrip, x_real, y_real, z);
+	  if(ClosestStrip>=1 && ClosestStrip<=N_str)
+	  { // store the closest and check neighborhood of the closest (~)
+	   
+	    for (int clus=0; clus<clust_size+1; clus++){
+	      //Look at the next strip
+	      strip_num=ClosestStrip+clus;
+	      if ((strip_num<N_halfstr+N_sidestr+1)||(ClosestStrip>=(N_halfstr+N_sidestr+1)&&strip_num>=(N_halfstr+N_sidestr+1)&&strip_num<N_str+1)){//Check if the strip exist or make sense to look at it
+		weight=Weight_td(strip_num, x_real, y_real, z);
+		strip_id.push_back(strip_num);
+		strip_id.push_back(weight);
+		
+		if (abs(strip_y)<y_central){//If in central part, then check the top/bottom strip systematically
+		  strip_num=2*N_halfstr+N_sidestr+1-strip_num;
+		  weight=Weight_td(strip_num, x_real, y_real, z);
+		  strip_id.push_back(strip_num);
+		  strip_id.push_back(weight);
+		}
+	      }
 
-	  if(y_real > -84.1 && y_real < 84.1 && x_real < 0){ // R_max - 3*64*0.525 - 0.5 = 84.1;
-		  ClosestStrip = (int) (floor((84.1-y_real)/pitch)+1);
-	  }
-	  else if(y_real < -84.1 && y_real > -184.9){ // R_max - 3*64*0.525 - 0.5 = 84.1; R_max - 0.5 = 184.9
-	  	ClosestStrip = (int) (floor((-y_real-84.1)/pitch)+1) + 320; // 5*64 = 320
-	  }
-	  else if(y_real > -84.1 && y_real < 84.1 && x_real > 0){ // R_max - 3*64*0.525 - 0.5 = 84.1;
-		  ClosestStrip = (int) (floor((y_real+84.1)/pitch)+1) + 512;	 // (5+3)*64 = 512
-	  }
-	  else if(y_real > 84.1 && y_real < 184.9){ // R_max - 3*64*0.525 - 0.5 = 84.1; R_max - 0.5 = 184.9
-		  ClosestStrip = (int) (floor((y_real-84.1)/pitch)+1) + 832; // (5+3+5)*64 = 832
-	  }
-
-	  if(sqrt(x*x+y*y)<R_max && sqrt(x*x+y*y)>R_min && ClosestStrip>=1 && ClosestStrip<=N_str)
-	  { // strip is in the acceptance (~)
-		  for(int istrip=0;istrip< (int) (strip_id.size()/2);istrip++)
-		  {
-			  if(strip_id[2*istrip]==ClosestStrip)
-			  {// already hit strip - add Edep
-				  strip_id[2*istrip+1]=strip_id[2*istrip+1]+1./((double) Nel); // no gain fluctuation yet
-				  ClosestStrip=-1; // not to use it anymore
-			  }
-		  }
-		  if(ClosestStrip>-1)
-		  { // this is a new strip
-			  strip_id.push_back(ClosestStrip);
-			  strip_id.push_back(1./((double) Nel)); // no gain fluctuation yet
-		  }
+	      //Look at the previous strip
+	      if (clus!=0){ //Avoid double counting
+		strip_num=ClosestStrip-clus;
+		if (strip_num<1||(strip_num<=N_halfstr+N_sidestr&&ClosestStrip>N_halfstr+N_sidestr)) strip_num=2*N_halfstr+N_sidestr+1-strip_num; //Deal with the discontinuity between strip 1 and 833, or 321-513.
+		weight=Weight_td(strip_num, x_real, y_real, z);
+		strip_id.push_back(strip_num);
+		strip_id.push_back(weight);
+		
+		if (abs(strip_y)<y_central){//If in central part, then check the top/bottom strip systematically
+		  strip_num=2*N_halfstr+N_sidestr+1-strip_num;
+		  weight=Weight_td(strip_num, x_real, y_real, z);
+		  strip_id.push_back(strip_num);
+		  strip_id.push_back(weight);
+		} 
+	      }
+	    }
+	     //We have computed the weight with a gaussian distribution. But considering the few electrons, it makes no sense.
+	    double Nel_left=Nel;
+	    double renorm=0;
+	    double weight_this_strip;
+	    int Nel_this_strip=0;
+	    for (int i=0;i<strip_id.size()/2;i++){
+	      if (renorm!=1&&Nel_left!=0){
+		weight_this_strip=strip_id.at(2*i+1)/(1-renorm);
+		Nel_this_strip=GetBinomial(Nel_left,weight_this_strip);
+		if (Nel_this_strip==-1) cout<<Nel_left<<" -1  "<<weight_this_strip<<endl;
+		renorm+=strip_id.at(2*i+1);
+		strip_id.at(2*i+1)=Nel_this_strip;
+		Nel_left-=Nel_this_strip;
+	      }
+	      //	cout<<"Strip number "<<strip_id.at(2*i)<<" "<<strip_id.at(2*i+1)<<endl;
+	    }
+	    if (Nel_left<0) cout<<"Warning in FMT hitprocess!!!!!!!!"<<endl;
 	  }
 	  else
-	  {// not in the acceptance
-		  strip_id.push_back(-1);
-		  strip_id.push_back(1);
+	  {// Warning - something is wrong
+	    cout<<"WARNING!!!!!! Something is wrong in FMT strip finder..... "<<ClosestStrip<<" "<<x_real<<" "<<y_real<<endl;
+	    strip_id.push_back(-1);
+	    strip_id.push_back(1);
 	  }
-		}
 	}
 	else
 	{ // Nel=0, consider the Edep is 0
 		strip_id.push_back(-1);
 		strip_id.push_back(1);
 	}
+
 	return strip_id;
 }
 
+void fmt_strip::Carac_strip(int strip){
+  if (strip<=N_str/2){
+    strip_y=y_central-(strip-0.5)*pitch;
+    }
+    else{
+      strip_y=-y_central+(strip-N_str/2-0.5)*pitch;
+    }
+    
+    //Give the strip length
+    strip_length=2*R_max*sin(acos(fabs(strip_y)/R_max));
+    if ((strip>N_halfstr&&strip<N_halfstr+N_sidestr+1)||(strip<N_str+1&&strip>2*N_halfstr+N_sidestr)) {
+      //strip_length=2*R_max*sin(acos(fabs(strip_y)/R_max));
+      strip_x=0;
+    }	
+    else{
+      //if (fabs(strip_length)/R_min<1){ 
+	if (fabs(strip_y)/R_min<1){
+	strip_length=R_max*sin(acos(fabs(strip_y)/R_max))-R_min*sin(acos(fabs(strip_y)/R_min));
+	if (strip<=N_str/2) 
+	  strip_x=-strip_length/2.-R_min*sin(acos(fabs(strip_y)/R_min));
+	else
+	  strip_x=strip_length/2.+R_min*sin(acos(fabs(strip_y)/R_min));
+      }
+      else{ 
+	strip_length=R_max*sin(acos(fabs(strip_y)/R_max));
+	if (strip<=N_str/2) 
+	  strip_x=-strip_length/2.;
+	else
+	  strip_x=strip_length/2.;
+      }
+    }
+}
 
 
+double fmt_strip::Weight_td(int strip, double x, double y, double z){
+  Carac_strip(strip);
+  double wght=(erf((strip_y+pitch/2.-y)/sigma_td/sqrt(2))-erf((strip_y-pitch/2.-y)/sigma_td/sqrt(2)))*(erf((strip_x+strip_length/2.-x)/sigma_td/sqrt(2))-erf((strip_x-strip_length/2.-x)/sigma_td/sqrt(2)))/2./2.;
+  if (wght<0) wght=-wght;
+  return wght;
+}
 
-
+double fmt_strip::GetBinomial(double n, double p){
+  double answer;
+  answer=CLHEP::RandBinomial::shoot(n,p);
+  //Very bad method when n=0 or p close to 0 or 1... return easily -1 in these case.
+  //So need to help in the limit condition
+  if (answer==-1){
+    answer=n;
+    if (p==0) answer=0;
+  }
+  return answer;
+}
 
 
 

--- a/hitprocess/clas12/micromegas/fmt_strip.h
+++ b/hitprocess/clas12/micromegas/fmt_strip.h
@@ -17,16 +17,25 @@ public:
 	vector<double> Z0;       // z of the upstream part of the layer
 	vector<double> alpha;    // strip angles of layers
 	int N_str;               // Number of strips for 1 layer
+	int N_halfstr;           // number of bottom strips in the central part
+	int N_sidestr;           // number of strips one side
+	double y_central;        // Limit the central part for stip finding
 	double hDrift;           // Size of the drift gap
 	double hStrip2Det;       // distance between strips and the middle of the conversion gap (~half the drift gap)
 	double sigma_td_max;     // maximum value of the transverse diffusion
 	double sigma_td;         // current value of the transverse diffusion
 	double w_i;              // mean ionization potential
+	int nb_sigma;            // Number of strips to study around the closest one
 	int Nel;                 // number of electrons (Nt) for a given hit
-	double y_real; 			 // y position of the hit after transverse diffusion
-	double x_real;			 // x position of the hit after transverse diffusion
+	double y_real; 		 // y position of the hit after transverse diffusion
+	double x_real;		 // x position of the hit after transverse diffusion
+	double strip_x;          // strip_x is the middle of the strips
+	double strip_y;          // strip_y is the position of the strips
+	double strip_length;     // length of the strip
 	void fill_infos();
 
 	vector<double> FindStrip( int layer, int sector, double x, double y, double z, double Edep);   // Strip Finding Routine
-
-};
+	void Carac_strip(int strip); //length of the strip
+	double Weight_td(int strip, double x, double y, double z); //Compute the fraction of Nel falling onto the strip, depending on x,y in the FMT coordinate system
+	double GetBinomial(double n, double p);//CLHEP Binomial has a weird limit condition which returns -1 instead of 0 when n*p=0
+ };


### PR DESCRIPTION
-Reduce the number of variables to define the geometry so that it is much easier to not forget something to update if needed
-Remove the for-loop over the number of electrons created in the drift space, replaced by a binomial distribution shoot once we have computed the likelihood for the strip to get an electron (Only computed in the neighborhood of the closest strip) 