### PR TITLE
mode1 data is written crate by crate, rather being written detector by detector

### DIFF
--- a/output/evio_output.h
+++ b/output/evio_output.h
@@ -50,6 +50,11 @@ class evio_output : public outputFactory
 	// write fadc mode 1 (full signal shape) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
 	virtual void writeFADCMode1(outputContainer*, vector<hitOutput>, int);
 
+        // write fadc mode 1 (full signal shape) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
+        // This method should be called once at the end of event action, and the 1st argument 
+        // is a map<int crate_id, vector<hitoutput> (vector of all hits from that crate) >
+	virtual void writeFADCMode1( map<int, vector<hitOutput> >, int);
+
 	// write fadc mode 7 (integrated mode) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
 	virtual void writeFADCMode7(outputContainer*, vector<hitOutput>, int);
 
@@ -76,6 +81,10 @@ class evio_output : public outputFactory
 //	static bool is_conf_written;
 	static vector<int> detector_crates;
 	
+        private:
+            
+        static const int fadc_mode1_banktag;
+        
 };
 
 // returns a evioDOMNodeP based on the type specified by the string

--- a/output/outputFactory.h
+++ b/output/outputFactory.h
@@ -256,6 +256,11 @@ public:
 	// write fadc mode 1 (full signal shape) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
 	virtual void writeFADCMode1(outputContainer*, vector<hitOutput>, int) = 0;
 
+        // write fadc mode 1 (full signal shape) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
+        // This method should be called once at the end of event action, and the 1st argument 
+        // is a map<int crate_id, vector<hitoutput> (vector of all hits from that crate) >
+	virtual void writeFADCMode1( map<int, vector<hitOutput> >, int)  = 0;
+        
 	// write fadc mode 7 (integrated mode) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
 	virtual void writeFADCMode7(outputContainer*, vector<hitOutput>, int) = 0;
 

--- a/output/txt_output.cc
+++ b/output/txt_output.cc
@@ -338,6 +338,11 @@ void txt_output :: writeFADCMode1(outputContainer* output, vector<hitOutput> HO,
 {
 }
 
+
+void txt_output :: writeFADCMode1( map<int, vector<hitOutput> >, int)
+{
+}
+
 // write fadc mode 7 (integrated mode) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
 void txt_output :: writeFADCMode7(outputContainer* output, vector<hitOutput> HO, int event_number)
 {

--- a/output/txt_output.h
+++ b/output/txt_output.h
@@ -16,8 +16,8 @@
 class txt_output : public outputFactory
 {
 	public:
-		~txt_output(){;}  ///< event is deleted in WriteEvent routine
-		static outputFactory *createOutput() {return new txt_output;}
+	~txt_output(){;}  ///< event is deleted in WriteEvent routine
+	static outputFactory *createOutput() {return new txt_output;}
 
 	// record the simulation conditions on the file
 	void recordSimConditions(outputContainer*, map<string, string>);
@@ -49,6 +49,9 @@ class txt_output : public outputFactory
 	// write fadc mode 1 (full signal shape) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
 	virtual void writeFADCMode1(outputContainer*, vector<hitOutput>, int);
 
+        // write fadc mode 1 (full signal shape) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
+        virtual void writeFADCMode1( map<int, vector<hitOutput> >, int);
+        
 	// write fadc mode 7 (integrated mode) - jlab hybrid banks. This uses the translation table to write the crate/slot/channel
 	virtual void writeFADCMode7(outputContainer*, vector<hitOutput>, int);
 

--- a/src/MEventAction.cc
+++ b/src/MEventAction.cc
@@ -406,6 +406,7 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 			//MHit* aHit = (*MHC)[0];
 			string vname = (*MHC)[0]->GetDetector().name;
 			string hitType = it->second->GetDetectorHitType(vname);
+			
 
 			if(hitType.find("mirror:") != string::npos) hitType = "mirror";
 
@@ -595,7 +596,8 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 			// using the SIGNALVT option
 			if(SIGNALVT.find(hitType) != string::npos) {
 				vector<hitOutput> allVTOutput;
-
+				
+				
 				for(int h=0; h<nhits; h++) {
 
 					hitOutput thisHitOutput;

--- a/src/MEventAction.cc
+++ b/src/MEventAction.cc
@@ -390,6 +390,11 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 	if(SAVE_ALL_MOTHERS>1)
 		saveBGPartsToLund();
 	
+        
+        
+        map<int, vector<hitOutput> > hit_outputs_from_AllSD;
+       
+        
 	for(map<string, sensitiveDetector*>::iterator it = SeDe_Map.begin(); it!= SeDe_Map.end(); it++)
 	{
 		MHC = it->second->GetMHitCollection();
@@ -614,9 +619,9 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 					map<int, int> vSignal;
 
 					// crate, slot, channels as from translation table
-					vSignal[0] = hardware[0];
-					vSignal[1] = hardware[1];
-					vSignal[2] = hardware[2];
+					vSignal[0] = hardware[0];           // crate
+					vSignal[1] = hardware[1];           // slot
+					vSignal[2] = hardware[2];           // channel
 
 					// Add comments what are these
 					double pedestal_mean = hardware[3];
@@ -656,6 +661,7 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 					}
 					thisHitOutput.createQuantumS(vSignal);
 					
+                                        hit_outputs_from_AllSD[vSignal[0]].push_back(thisHitOutput);
 					allVTOutput.push_back(thisHitOutput);
 					
 					// this is not written out yet
@@ -674,12 +680,16 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 				processOutputFactory->writeChargeTime(outContainer, allVTOutput, hitType, banksMap);
 				
 				// Event number (evtN) is needed in FADCMode1, therefore this is also passed as an argument
-				processOutputFactory->writeFADCMode1(outContainer, allVTOutput, evtN);
+				//processOutputFactory->writeFADCMode1(outContainer, allVTOutput, evtN);
+                                
 			}
 
 			delete hitProcessRoutine;
 		}
 	}
+        
+        processOutputFactory->writeFADCMode1( hit_outputs_from_AllSD, evtN);
+        
 	// writing out generated particle infos
 	processOutputFactory->writeGenerated(outContainer, MPrimaries, banksMap, gen_action->userInfo);
 	


### PR DESCRIPTION
A new overloaded method "writeFADCMode1( map<int,  vector<hitOutput> > HO , int ev_number)" is added into the evio_output. The old writeFADCMode1(outputContainer* output, vector<hitOutput> HO, int ev_number), is kept just in case, but is not used currently.

This method writeFADCMode1( map<int,  vector<hitOutput> > HO , int ev_number) is called only once per event, in the MEventAction.cc, after the processing all hists from all Sensitive Detectors.