### PR TITLE
Fix list of physics processes

### DIFF
--- a/physics/PhysicsList.cc
+++ b/physics/PhysicsList.cc
@@ -71,9 +71,14 @@ PhysicsList::PhysicsList(goptions opts) : G4VModularPhysicsList()
 		vector<string> emstripped = getStringVectorFromStringWithDelimiter(allEM[i], "_");
 		string stripped;
 
-		if(emstripped.size() == 2) stripped = trimSpacesFromString(emstripped[1]);
-		if(stripped != "")
-			g4EMList.push_back(stripped);
+		if(emstripped.size() == 2)
+			stripped = trimSpacesFromString(emstripped[1]);
+		else if (emstripped.size() == 1)
+			stripped = emstripped[0];
+		else
+			continue;
+
+		g4EMList.push_back(stripped);
 
 	}
 
@@ -405,13 +410,3 @@ void PhysicsList::ConstructProcess()
 		}
 	}
 }
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Before this patch, an error is raised when attempting to load an EM physics process e.g LIV instead of STD