### PR TITLE
Change bmt pre-initilization to fix #139

### DIFF
--- a/hitprocess/clas12/micromegas/BMT_hitprocess.cc
+++ b/hitprocess/clas12/micromegas/BMT_hitprocess.cc
@@ -16,6 +16,11 @@ static bmtConstants initializeBMTConstants(int runno)
 {
 	// all these constants should be read from CCDB
 	bmtConstants bmtc;
+	
+	// do not initialize at the beginning, only after the end of the first event,
+    	// with the proper run number coming from options or run table
+	if(runno == -1) return bmtc;
+	
 	bmtc.runNo = runno;
 	
 	if(getenv ("CCDB_CONNECTION") != NULL) {
@@ -101,12 +106,6 @@ static bmtConstants initializeBMTConstants(int runno)
 	//bmtc.changeFieldScale(-1);  // this needs to be read from DB
 
 	bmtc.Lor_Angle.Initialize(runno);
-	
-	if(runno == -1)
-	{
-		cout << " > bmt pre-initizialization. " << endl;
-		return bmtc;
-	}
 
 	return bmtc;
 }


### PR DESCRIPTION
Change when to return if pre-initialization process and Fixes #139. Currently there is no difference if we are pre-initilizing or initializing with a run number, except for the print statement. Returning after creating the object is how other detector systems are initialized so this should work the same way. See: source/hitprocess/clas12/ctof_hitprocess.cc line 25, source/hitprocess/clas12/ftof_hitprocess.cc line 22, source/hitprocess/clas12/ec_hitprocess.cc line 19, etc.