### PR TITLE
SAVE_SELECTED option to save selected event RNG states

### DIFF
--- a/src/MEventAction.h
+++ b/src/MEventAction.h
@@ -92,14 +92,14 @@ vector<G4ThreeVector> vector_mvert(  map<int, TInfos> tinfos, vector<int> tids);
 vector<int>           vector_zint(  int size);  ///< provides a vector of 0
 vector<G4ThreeVector> vector_zthre( int size);  ///< provides a vector of (0,0,0)
 
-/// \class saveSelectedParams
-/// <b> saveSelectedParams </b>\n\n
+/// \class saveEventParams
+/// <b> saveEventParams </b>\n\n
 /// Holds parameters from the SAVE_SELECTED option
-class saveSelectedParams
+class saveEventParams
 {
  public:
-  saveSelectedParams () {;}
-  ~saveSelectedParams() {;}
+  saveEventParams () {;}
+  ~saveEventParams() {;}
 
   bool enabled;
   string targetId;
@@ -171,7 +171,7 @@ public:
 	map<int, BGParts> bgMap;
 
 	// SAVE_SELECTED parameters
-	saveSelectedParams ssp;
+	saveEventParams ssp;
 
 
 private:

--- a/src/MEventAction.h
+++ b/src/MEventAction.h
@@ -92,6 +92,26 @@ vector<G4ThreeVector> vector_mvert(  map<int, TInfos> tinfos, vector<int> tids);
 vector<int>           vector_zint(  int size);  ///< provides a vector of 0
 vector<G4ThreeVector> vector_zthre( int size);  ///< provides a vector of (0,0,0)
 
+/// \class saveSelectedParams
+/// <b> saveSelectedParams </b>\n\n
+/// Holds parameters from the SAVE_SELECTED option
+class saveSelectedParams
+{
+ public:
+  saveSelectedParams () {;}
+  ~saveSelectedParams() {;}
+
+  bool enabled;
+  string targetId;
+  unsigned tIdsize;
+  int targetPid;
+  double lowLim;
+  double hiLim;
+  string variable;
+  string dir;
+  bool decision;
+};
+
 
 /// \class MEventAction
 /// <b> MEventAction </b>\n\n
@@ -149,6 +169,9 @@ public:
 	void saveBGPartsToLund();
 	ofstream *lundOutput;
 	map<int, BGParts> bgMap;
+
+	// SAVE_SELECTED parameters
+	saveSelectedParams ssp;
 
 
 private:

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -595,6 +595,16 @@ void goptions::setGoptions()
 	optMap["TSAMPLING"].name = "Sampling time of electronics (typically FADC)";
 	optMap["TSAMPLING"].type = 1;
 	optMap["TSAMPLING"].ctgr = "output";
+
+	// Activates RNG saving for selected events
+	optMap["SAVE_SELECTED"].args  = "";
+	optMap["SAVE_SELECTED"].help  = "Save events with selected hit types\n";
+	optMap["SAVE_SELECTED"].help  = "  arg is list of id, pid, low limit, high limit, variable[, directory]\n";
+	optMap["SAVE_SELECTED"].help  = "  e.g. 7xx10000, 11, 0.0*MeV, 2000*MeV, trackE, /.\n";
+	optMap["SAVE_SELECTED"].name  = "Save events with selected hit types";
+	optMap["SAVE_SELECTED"].type  = 1;
+	optMap["SAVE_SELECTED"].ctgr  = "output";
+	
 	
 
 	// Physics


### PR DESCRIPTION
Provides and implements a new command line option:

-SAVE_SELECTED=“&lt;id&gt;, &lt;pid&gt;, &lt;low limit&gt;, &lt;high limit&gt;, &lt;variable&gt;, &lt;directory&gt;”

This tells GEMC to save the RNG state in a file in directory <directory> for events in which there is a hit satisfying:

* Detector ID matches &lt;id&gt; in all digit positions where &lt;id&gt; does not contain ‘x’ AND

* Particle ID is &lt;pid&gt; AND

* &lt;variable&gt; is in the range from &lt;low limit&gt; to &lt;high limit&gt;

&lt;directory&gt; is optional and defaults to the current directory

For example SAVE_SELECTED="7xx10000, 11, 0.0*MeV, 2000*MeV, trackE, ./” saves RNG state in files in the current directory for events in which there was a hit in detectors 70010000, 70110000, 70210000, etc. by an electron with energy from 0 to 2 GeV.