### PR TITLE
Ancestors

### DIFF
--- a/output/evio_output.cc
+++ b/output/evio_output.cc
@@ -135,6 +135,8 @@ void evio_output :: writeGenerated(outputContainer* output, vector<generatedPart
 	int fastMCMode          = output->gemcOpt.optMap["FASTMCMODE"].arg;  
 
 	if(fastMCMode>0) SAVE_ALL_MOTHERS = 1;
+ 	if (output->gemcOpt.optMap["SAVE_ALL_ANCESTORS"].arg && (SAVE_ALL_MOTHERS == 0))
+	  SAVE_ALL_MOTHERS = 1;
 
 	gBank bank  = getBankFromMap("generated", banksMap);
 	gBank sbank = getBankFromMap("psummary", banksMap);
@@ -267,6 +269,59 @@ void evio_output :: writeGenerated(outputContainer* output, vector<generatedPart
 	}
 	*event << userInfoBank;
 
+}
+
+void evio_output :: writeAncestors (outputContainer* output, vector<ancestorInfo> ainfo, gBank bank)
+{
+  vector<int> pid;
+  vector<int> tid;
+  vector<int> mtid;
+  vector<double> trackE;
+  vector<double> px;
+  vector<double> py;
+  vector<double> pz;
+  vector<double> vx;
+  vector<double> vy;
+  vector<double> vz;
+  
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    {
+      pid.push_back (ainfo[i].pid);
+      tid.push_back (ainfo[i].tid);
+      mtid.push_back (ainfo[i].mtid);
+      trackE.push_back (ainfo[i].trackE);
+      px.push_back (ainfo[i].p.getX()/MeV);
+      py.push_back (ainfo[i].p.getY()/MeV);
+      pz.push_back (ainfo[i].p.getZ()/MeV);
+      vx.push_back (ainfo[i].vtx.getX()/MeV);
+      vy.push_back (ainfo[i].vtx.getY()/MeV);
+      vz.push_back (ainfo[i].vtx.getZ()/MeV);
+    }
+
+  // creating and inserting ancestors bank  
+  evioDOMNodeP ancestorsp = evioDOMNode::createEvioDOMNode(ANCESTORS_BANK_TAG, 0);
+  
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("pid"),
+			   bank.getVarType("pid"), pid);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("tid"),
+			   bank.getVarType("tid"), tid);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("mtid"),
+			   bank.getVarType("mtid"), mtid);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("trackE"),
+			   bank.getVarType("trackE"), trackE);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("px"),
+			   bank.getVarType("px"),  px);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("py"),
+			   bank.getVarType("py"),  py);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("pz"),
+			   bank.getVarType("pz"),  pz);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("vx"),
+			   bank.getVarType("vx"),  vx);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("vy"),
+			   bank.getVarType("vy"),  vy);
+  *ancestorsp << addVector(ANCESTORS_BANK_TAG, bank.getVarId("vz"),
+			   bank.getVarType("vz"),  vz);
+  *event << ancestorsp;
 }
 
 void evio_output :: initBank(outputContainer* output, gBank thisHitBank, int what)

--- a/output/evio_output.h
+++ b/output/evio_output.h
@@ -35,6 +35,9 @@ class evio_output : public outputFactory
 	// write generated particles
 	void writeGenerated(outputContainer*, vector<generatedParticle>, map<string, gBank> *banksMap, vector<userInforForParticle> userInfo);
 
+	// write ancestors
+	virtual void writeAncestors (outputContainer*, vector<ancestorInfo>, gBank);
+
 	// write RF Signal
 	virtual void writeRFSignal(outputContainer*, FrequencySyncSignal, gBank);
 

--- a/output/gbank.cc
+++ b/output/gbank.cc
@@ -196,6 +196,23 @@ map<string, gBank> read_banks(goptions gemcOpt, map<string, string> allSystems)
 	abank.orderNames();
 	banks["counter"]   = abank;
 
+
+	// ancestors bank 
+	// Information about ancestral trajectories
+	abank =  gBank (ANCESTORS_BANK_TAG, "ancestors", "Geant4 ancestors information");
+	abank.load_variable ("pid",     1,   "Ri", "ID of the ancestor");
+	abank.load_variable ("tid",     2,   "Ri", "Track ID of the ancestor");
+	abank.load_variable ("mtid",    3,   "Ri", "Track ID of the mother of the ancestor");
+	abank.load_variable ("trackE",  4,   "Rd", "Energy of the ancestor");
+	abank.load_variable ("px",      5,   "Rd", "x component of momentum of the ancestor");
+	abank.load_variable ("py",      6,   "Rd", "y component of momentum of the ancestor");
+	abank.load_variable ("pz",      7,   "Rd", "z component of momentum of the ancestor");
+	abank.load_variable ("vx",      5,   "Rd", "x component of vertex of the ancestor");
+	abank.load_variable ("vy",      6,   "Rd", "y component of vertex of the ancestor");
+	abank.load_variable ("vz",      7,   "Rd", "z component of vertex of the ancestor");
+	abank.orderNames();
+	banks["ancestors"]   = abank;
+
 	
 	// Loading all banks related to a system
 	// then checking that all sensitive detectors have a bank

--- a/output/gbank.h
+++ b/output/gbank.h
@@ -48,6 +48,9 @@ using namespace std;
 // COUNTER Bank
 #define COUNTER_BANK_TAG 70
 
+// Ancestors Bank
+#define ANCESTORS_BANK_TAG 80
+
 // These Bank Types ID can be left hardcoded here
 #define DETECTOR_BANK_ID 0
 

--- a/output/outputFactory.cc
+++ b/output/outputFactory.cc
@@ -94,3 +94,25 @@ double generatedParticle::getVariableFromStringD(string what)
 
 	return 0;
 }
+
+int ancestorInfo::getVariableFromStringI(string what)
+{
+  if (what == "pid")          return pid;
+  else if (what == "tid")     return tid;
+  else if (what == "mtid")    return mtid;
+
+  return 0;
+}
+
+double ancestorInfo::getVariableFromStringD(string what)
+{
+  if (what == "trackE")   return trackE;
+  else if (what == "px")   return p.x();
+  else if (what == "py")   return p.y();
+  else if (what == "pz")   return p.z();
+  else if (what == "vx")   return vtx.x();
+  else if (what == "vy")   return vtx.y();
+  else if (what == "vz")   return vtx.z();
+  
+  return 0;
+}

--- a/output/outputFactory.h
+++ b/output/outputFactory.h
@@ -212,6 +212,9 @@ class ancestorInfo
   double trackE;
   G4ThreeVector p;
   G4ThreeVector vtx;
+
+  int    getVariableFromStringI(string);
+  double getVariableFromStringD(string);
 };
 
 

--- a/output/outputFactory.h
+++ b/output/outputFactory.h
@@ -201,6 +201,18 @@ public:
 };
 
 
+class ancestorInfo
+{
+ public:
+  ancestorInfo() {};
+  ~ancestorInfo() {};
+  int pid;
+  int tid;
+  int mtid;
+  double trackE;
+  G4ThreeVector p;
+  G4ThreeVector vtx;
+};
 
 
 /// \class outputContainer
@@ -243,6 +255,9 @@ public:
 
 	// write generated particles
 	virtual void writeGenerated(outputContainer*, vector<generatedParticle>, map<string, gBank> *banksMap, vector<userInforForParticle> userInfo) = 0;
+
+	// write ancestors
+	virtual void writeAncestors (outputContainer*, vector<ancestorInfo>, gBank) = 0;
 
 	// write geant4 true integrated info
 	virtual void writeG4RawIntegrated(outputContainer*, vector<hitOutput>, string, map<string, gBank>*) = 0;

--- a/output/txt_output.cc
+++ b/output/txt_output.cc
@@ -157,6 +157,28 @@ void txt_output :: writeGenerated(outputContainer* output, vector<generatedParti
 	*txtout << " --- End of Generated Particles Bank -- " << endl;
 }
 
+void txt_output :: writeAncestors (outputContainer* output, vector<ancestorInfo> ainfo, gBank bank)
+{
+  ofstream *txtout = output->txtoutput ;
+
+  *txtout << " --- Ancestors Bank -- " << endl;
+
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    {
+      *txtout << "   - Trajectory " << i+1 << " pid: " << ainfo[i].pid
+	      << "  - tid: " << ainfo[i].tid
+	      << "  - mtid: " << ainfo[i].mtid
+	      << "  - E: " << ainfo[i].trackE/MeV
+	      << " MeV  - mom: " << ainfo[i].p.getX()/MeV
+	      << " " << ainfo[i].p.getY()/MeV
+	      << " " << ainfo[i].p.getZ()/MeV
+	      << " MeV  - vtx: " << ainfo[i].vtx.getX()/MeV
+	      << " " << ainfo[i].vtx.getY()/MeV
+	      << " " << ainfo[i].vtx.getZ()/MeV
+	      << " mm" << endl;
+    }
+}
+
 void txt_output ::  initBank(outputContainer* output, gBank thisHitBank)
 {
 	if(!insideBank[thisHitBank.bankName])

--- a/output/txt_output.h
+++ b/output/txt_output.h
@@ -34,6 +34,9 @@ class txt_output : public outputFactory
 	// write generated particles
 	void writeGenerated(outputContainer*, vector<generatedParticle>, map<string, gBank> *banksMap, vector<userInforForParticle> userInfo);
 	
+	// write ancestors
+	virtual void writeAncestors (outputContainer*, vector<ancestorInfo>, gBank);
+
 	// format output and set insideBank
 	void initBank(outputContainer*, gBank);
 	

--- a/output/txt_simple_output.cc
+++ b/output/txt_simple_output.cc
@@ -178,6 +178,56 @@ void txt_simple_output :: writeGenerated(outputContainer* output, vector<generat
 	*txtout << indent(1) << "}" << endl;
 }
 
+void txt_simple_output :: writeAncestors (outputContainer* output, vector<ancestorInfo> ainfo, gBank bank)
+{
+  ofstream *txtout = output->txtoutput ;
+
+  *txtout << indent(1) << "Ancestors Bank {" << endl;
+
+  *txtout << indent(2) << " pid:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].pid << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " tid:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].tid << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " mtid:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].mtid << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " E:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].trackE/MeV << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " px:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].p.x()/MeV << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " py:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].p.y()/MeV << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " pz:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].p.z()/MeV << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " vx:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].vtx.x()/MeV << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " vy:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].vtx.y()/MeV << "\t";
+  *txtout<< endl;
+  *txtout << indent(2) << " vz:\t";
+  for (unsigned i = 0; i < ainfo.size(); i++)
+    *txtout << ainfo[i].vtx.z()/MeV << "\t";
+  *txtout<< endl;
+  *txtout << indent(1) << "}" << endl;
+
+}
+
 void txt_simple_output ::  initBank(outputContainer* output, gBank thisHitBank)
 {
 }

--- a/output/txt_simple_output.h
+++ b/output/txt_simple_output.h
@@ -36,6 +36,9 @@ class txt_simple_output : public outputFactory
 	// write generated particles
 	void writeGenerated(outputContainer*, vector<generatedParticle>, map<string, gBank> *banksMap, vector<userInforForParticle> userInfo);
 
+	// write ancestors
+	virtual void writeAncestors (outputContainer*, vector<ancestorInfo>, gBank);
+
 	// format output and set insideBank
 	void initBank(outputContainer*, gBank);
 

--- a/src/MEventAction.h
+++ b/src/MEventAction.h
@@ -150,6 +150,7 @@ public:
 	double VERB;            ///< Event Verbosity
 	string catch_v;         ///< Print Log for volume
 	int   SAVE_ALL_MOTHERS; ///< >= 1: Loops over the stored trajectories to store mother vertex and pid in the output. >=2: Also saves all particles that produced a hit onto LUND format
+	int SAVE_ALL_ANCESTORS; ///< Outputs info on all ancestors of tracks with hits
 	int   MAXP;             ///< Max number of generated particles to save on output stream
 	string WRITE_ALLRAW;    ///< List of detectors for which geant4 all raw info need to be saved
 	string WRITE_INTRAW;    ///< List of detectors for which geant4 raw integrated info need to be saved

--- a/src/MEventAction.h
+++ b/src/MEventAction.h
@@ -92,14 +92,14 @@ vector<G4ThreeVector> vector_mvert(  map<int, TInfos> tinfos, vector<int> tids);
 vector<int>           vector_zint(  int size);  ///< provides a vector of 0
 vector<G4ThreeVector> vector_zthre( int size);  ///< provides a vector of (0,0,0)
 
-/// \class saveSelectedParams
-/// <b> saveSelectedParams </b>\n\n
+/// \class saveEventParams
+/// <b> saveEventParams </b>\n\n
 /// Holds parameters from the SAVE_SELECTED option
-class saveSelectedParams
+class saveEventParams
 {
  public:
-  saveSelectedParams () {;}
-  ~saveSelectedParams() {;}
+  saveEventParams () {;}
+  ~saveEventParams() {;}
 
   bool enabled;
   string targetId;
@@ -172,7 +172,7 @@ public:
 	map<int, BGParts> bgMap;
 
 	// SAVE_SELECTED parameters
-	saveSelectedParams ssp;
+	saveEventParams ssp;
 
 
 private:

--- a/src/dmesg_init.cc
+++ b/src/dmesg_init.cc
@@ -25,6 +25,8 @@ vector<string> init_dmesg(goptions gemcOpt)
 	int   OVERL            = (int) gemcOpt.optMap["CHECK_OVERLAPS"].arg ;
 	int   DAWN_N           = (int) gemcOpt.optMap["DAWN_N"].arg ;
 	int   SAVE_ALL_MOTHERS = (int) gemcOpt.optMap["SAVE_ALL_MOTHERS"].arg ;
+	if (gemcOpt.optMap["SAVE_ALL_ANCESTORS"].arg && (SAVE_ALL_MOTHERS == 0))
+	  SAVE_ALL_MOTHERS = 1;
 	
 	char phi_verb[2];
 	sprintf(phi_verb, "%d", (int) PHI_VERB);

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -474,6 +474,12 @@ void goptions::setGoptions()
 	optMap["SAVE_ALL_MOTHERS"].type = 0;
 	optMap["SAVE_ALL_MOTHERS"].ctgr = "control";
 	
+	optMap["SAVE_ALL_ANCESTORS"].arg = 0;
+	optMap["SAVE_ALL_ANCESTORS"].name = "Set to 1 to save all ancestors of hits in output. High Memory Usage";
+	optMap["SAVE_ALL_ANCESTORS"].help  = "Set to 1 to save all ancestors of hits. High Memory Usage. Default is 0.\n";
+	optMap["SAVE_ALL_ANCESTORS"].type = 0;
+	optMap["SAVE_ALL_ANCESTORS"].ctgr = "control";
+	
 	optMap["HIGH_RES"].arg = 1;
 	optMap["HIGH_RES"].name = "Use High Resolution Graphics";
 	optMap["HIGH_RES"].help = "Use High Resolution Graphics\n";


### PR DESCRIPTION
Implement ancestral trajectory saving to output. This is enabled with the option SAVE_ALL_ANCESTORS=1. Then information about any trajectories which are ancestral to hits in the detectors is written to a new bank named ancestors

This can be useful particularly in combination with the RNG saving, especially once we work up a convenient way to rerun multiple events with saved RNG: run with SAVE_SELECTED=<something> and the default SAVE_ALL_ANCESTORS=0 to get the RNG for the few events of interest, then rerun them with SAVE_ALL_ANCESTORS=1, then do post-analysis of their trajectory history.
