### PR TITLE
Fix seg fault at eof of input file

### DIFF
--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -417,6 +417,8 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 			string theWholeLine;
 			// reading header
 			getline(gif, theWholeLine);
+			if (gif.eof())
+			  return;
 			vector<string> headerStrings = getStringVectorFromString(theWholeLine);
 			headerUserDefined.clear();
 			for(auto &s : headerStrings) {


### PR DESCRIPTION
GeneratePrimaries seg faults at the end of a LUND input file due to failure to check for eof immediately after getline; this fixes it.

