### PR TITLE
Rerunlund

### DIFF
--- a/src/MEventAction.cc
+++ b/src/MEventAction.cc
@@ -222,13 +222,9 @@ void MEventAction::BeginOfEventAction(const G4Event* evt)
 
 void MEventAction::EndOfEventAction(const G4Event* evt)
 {
-  cout << "eea " << evtN << endl;
-
   if ((gen_action->isFileOpen() == false) ||
       (gen_action->doneRerun() == true))
       return;
-
-  cout << "proceeding" << endl;
 
 	MHitCollection* MHC;
 	int nhits;
@@ -905,10 +901,8 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 
 	// Save RNG; can't use G4RunManager::GetRunManager()->rndmSaveThisEvent()
 	// because GEANT doesn't know about GEMC run/event numbers
-	cout << ">>>>> ssp.decision" << endl;
 	if (ssp.decision)
 	  {
-	    cout << ">>>>> ssp.decision true" << endl;
 	    G4String fileIn  = ssp.dir + "currentEvent.rndm";
 
 	    std::ostringstream os;
@@ -919,7 +913,6 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 	    G4String copCmd = "/control/shell cp "+fileIn+" "+fileOut;
 	    G4UImanager::GetUIpointer()->ApplyCommand(copCmd);
 	  }
-	cout << ">>>>> ssp.decision done" << endl;
 	
 	if(evtN%Modulo == 0 )
 		cout << hd_msg << " End of Event " << evtN << " Routine..." << endl << endl;

--- a/src/MEventAction.cc
+++ b/src/MEventAction.cc
@@ -179,12 +179,18 @@ MEventAction::~MEventAction()
 
 void MEventAction::BeginOfEventAction(const G4Event* evt)
 {
+        G4RunManager *runManager = G4RunManager::GetRunManager();;
 	if(gen_action->isFileOpen() == false) {
-		G4RunManager *runManager = G4RunManager::GetRunManager();;
 		runManager->AbortRun();
 		cout << " No more events in the input file." << endl;
 		return;
 	}
+	
+	MPrimaryGeneratorAction* pga = (MPrimaryGeneratorAction*)(runManager->GetUserPrimaryGeneratorAction());
+	if (pga->doneRerun())
+	  return;
+	if (pga->isRerun())
+	  evtN = pga->rerunEvent();
 
 	rw.getRunNumber(evtN);
 	bgMap.clear();

--- a/src/MEventAction.h
+++ b/src/MEventAction.h
@@ -112,6 +112,19 @@ class saveEventParams
   bool decision;
 };
 
+/// \class rerunEventParams
+/// <b> rerunEventParams </b>\n\n
+/// Holds parameters from the SAVE_SELECTED option
+class rerunEventParams
+{
+ public:
+  rerunEventParams () {;}
+  ~rerunEventParams() {;}
+
+  bool enabled;
+  string dir;
+};
+
 
 /// \class MEventAction
 /// <b> MEventAction </b>\n\n
@@ -172,7 +185,7 @@ public:
 
 	// SAVE_SELECTED parameters
 	saveEventParams ssp;
-
+	rerunEventParams rsp;
 
 private:
 	// background hits, key is event number

--- a/src/MEventAction.h
+++ b/src/MEventAction.h
@@ -123,6 +123,9 @@ class rerunEventParams
 
   bool enabled;
   string dir;
+  unsigned run;
+  vector<unsigned> events;
+  int currentevent;
 };
 
 

--- a/src/MEventAction.h
+++ b/src/MEventAction.h
@@ -112,22 +112,6 @@ class saveEventParams
   bool decision;
 };
 
-/// \class rerunEventParams
-/// <b> rerunEventParams </b>\n\n
-/// Holds parameters from the SAVE_SELECTED option
-class rerunEventParams
-{
- public:
-  rerunEventParams () {;}
-  ~rerunEventParams() {;}
-
-  bool enabled;
-  string dir;
-  unsigned run;
-  vector<unsigned> events;
-  int currentevent;
-};
-
 
 /// \class MEventAction
 /// <b> MEventAction </b>\n\n
@@ -188,7 +172,6 @@ public:
 
 	// SAVE_SELECTED parameters
 	saveEventParams ssp;
-	rerunEventParams rsp;
 
 private:
 	// background hits, key is event number

--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -17,6 +17,8 @@
 using namespace gstring;
 
 // C++ headers
+#include <sys/types.h>
+#include <dirent.h>
 #include <iostream>
 using namespace std;
 
@@ -122,11 +124,88 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 
     eventIndex = 1;
 
+  // Set up to read saved RNGs
+
+    string arg = gemcOpt->optMap["RERUN_SELECTED"].args;
+    cout << ">>>>>> setup RERUN_SELECTED: [" << arg << "]" << endl;
+    if (arg == "" || arg == "no")
+      rsp.enabled = false;
+    else
+      {
+	vector<string> values;
+	string units;
+	values       = get_info(gemcOpt->optMap["RERUN_SELECTED"].args, string(",\""));
+	if (values.size() <= 2)
+	  {
+	    rsp.enabled = true;
+	    rsp.run = get_number (values[0]);
+	    if (values.size() == 1)
+	      rsp.dir = "./";
+	    else
+	      {
+		rsp.dir = values[1];
+		if (rsp.dir[rsp.dir.size()-1] != '/' ) rsp.dir += "/";
+#ifdef WIN32
+		std::replace(rsp.dir.begin(), rsp.dir.end(),'/','\\');
+#endif
+	      }
+	    
+	    DIR* dirp = opendir(rsp.dir.c_str());
+	    struct dirent * dp;
+	    while ((dp = readdir(dirp)) != NULL)
+	      {
+		string dname (dp->d_name);
+		size_t rpos = dname.find ("run");
+		size_t epos = dname.find ("evt");
+		size_t rnpos = dname.find (".rndm");
+		if (rpos == string::npos || epos == string::npos
+		    || rnpos != dname.size()-5)
+		  continue;
+		
+		unsigned rstring = get_number (dname.substr (rpos+3, epos-rpos-3));
+		if (rstring == rsp.run)
+		  {
+		    string estring = dname.substr (epos+3, rnpos-epos-3);
+		    rsp.events.push_back (atoi (estring.c_str()));
+		    cout << dname << " " << epos << " " << string::npos << " " << estring << endl;
+		  }
+	      }
+	    closedir(dirp);
+	    std::sort (rsp.events.begin(), rsp.events.end());
+	    cout << "sorted:" << endl;
+	    for (vector<unsigned>::const_iterator i = rsp.events.begin(); i != rsp.events.end(); ++i)
+	      cout << (*i) << endl;
+	    rsp.currentevent = -1;
+	  }
+      }
 }
 
 
 void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 {
+  // Check first if event should be seeded
+
+  if (rsp.enabled)
+    {
+      G4RunManager *runManager = G4RunManager::GetRunManager();;
+      ++rsp.currentevent;
+      if (rsp.currentevent < int(rsp.events.size()))
+	{
+	  cout << "Here I would set up event " << rsp.events[rsp.currentevent] << endl;
+	  std::ostringstream os;
+	  os << "run" << rsp.run << "evt" << rsp.events[rsp.currentevent]
+	     << ".rndm" << '\0';
+	  G4String fileOut = rsp.dir + os.str();
+	  //	  runManager->RestoreRandomNumberStatus (fileOut);
+	  HepRandom::restoreEngineStatus(fileOut);
+	}
+      else
+	{
+	  runManager->AbortRun();
+	  cout << " No more events to rerun." << endl;
+	  return;
+	}
+    }
 
 	// internal generator. Particle defined by command line
 	if(input_gen == "gemc_internal")
@@ -417,6 +496,8 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 			string theWholeLine;
 			// reading header
 			getline(gif, theWholeLine);
+			if (gif.eof())
+			  return;
 			vector<string> headerStrings = getStringVectorFromString(theWholeLine);
 			headerUserDefined.clear();
 			for(auto &s : headerStrings) {

--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -127,7 +127,6 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
   // Set up to read saved RNGs
 
     string arg = gemcOpt->optMap["RERUN_SELECTED"].args;
-    cout << ">>>>>> setup RERUN_SELECTED: [" << arg << "]" << endl;
     if (arg == "" || arg == "no")
       rsp.enabled = false;
     else
@@ -167,14 +166,10 @@ MPrimaryGeneratorAction::MPrimaryGeneratorAction(goptions *opts)
 		  {
 		    string estring = dname.substr (epos+3, rnpos-epos-3);
 		    rsp.events.push_back (atoi (estring.c_str()));
-		    cout << dname << " " << epos << " " << string::npos << " " << estring << endl;
 		  }
 	      }
 	    closedir(dirp);
 	    std::sort (rsp.events.begin(), rsp.events.end());
-	    cout << "sorted:" << endl;
-	    for (vector<unsigned>::const_iterator i = rsp.events.begin(); i != rsp.events.end(); ++i)
-	      cout << (*i) << endl;
 	    rsp.currentevent = -1;
 	  }
       }
@@ -191,11 +186,12 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       ++rsp.currentevent;
       if (rsp.currentevent < int(rsp.events.size()))
 	{
-	  cout << "Here I would set up event " << rsp.events[rsp.currentevent] << endl;
 	  std::ostringstream os;
 	  os << "run" << rsp.run << "evt" << rsp.events[rsp.currentevent]
 	     << ".rndm" << '\0';
 	  G4String fileOut = rsp.dir + os.str();
+	  // Use restoreEngineStatus since RestoreRandomNumberStatus is
+	  // too verbose
 	  //	  runManager->RestoreRandomNumberStatus (fileOut);
 	  HepRandom::restoreEngineStatus(fileOut);
 	}

--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -490,6 +490,33 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 			headerUserDefined.clear();
 
 			string theWholeLine;
+
+			if (rsp.enabled && eventIndex < int (rsp.events[rsp.currentevent]))
+			  {
+			    // Skip input file lines to find rerun event
+			    for (; eventIndex < int (rsp.events[rsp.currentevent]); ++eventIndex)
+			      {
+				// reading header
+				getline(gif, theWholeLine);
+				if (gif.eof())
+				  return;
+				vector<string> headerStrings = getStringVectorFromString(theWholeLine);
+				headerUserDefined.clear();
+				for(auto &s : headerStrings) {
+				  headerUserDefined.push_back(get_number(s));
+				}
+				
+				int nparticles = headerUserDefined[0];
+				for(int p=0; p<nparticles; p++) {
+				  string theWholeLine;
+				  getline(gif, theWholeLine);
+				  if(gif.eof() && p != nparticles -1) {
+				    cout << " Input file " << gfilename << " appear to be truncated." << endl;
+				    return;
+				  }
+				}
+			      }
+			  }
 			// reading header
 			getline(gif, theWholeLine);
 			if (gif.eof())
@@ -546,8 +573,8 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
                 if(GEN_VERBOSITY > 3) {
                     cout << " This event will be skipped." << endl;
                 }
-                eventIndex++;
             }
+	    eventIndex++;
 		}
 		else if((gformat == "BEAGLE" || gformat == "beagle") && !gif.eof())
 		{

--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -73,6 +73,8 @@ public:
 
 	bool isFileOpen() {return !gif.eof();}
 
+	bool isRerun() { return rsp.enabled; }
+	int rerunEvent() { return rsp.currentevent >=0 ? rsp.events[rsp.currentevent] : 0; }
 	bool doneRerun() { return (rsp.enabled && rsp.currentevent >= int(rsp.events.size())); }
 
 private:

--- a/src/MPrimaryGeneratorAction.h
+++ b/src/MPrimaryGeneratorAction.h
@@ -24,6 +24,23 @@ public:
 	vector<double> infos;
 };
 
+/// \class rerunEventParams
+/// <b> rerunEventParams </b>\n\n
+/// Holds parameters from the SAVE_SELECTED option
+class rerunEventParams
+{
+ public:
+  rerunEventParams () {;}
+  ~rerunEventParams() {;}
+
+  bool enabled;
+  string dir;
+  unsigned run;
+  vector<unsigned> events;
+  int currentevent;
+};
+
+
 // Class definition
 class MPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 {
@@ -46,6 +63,7 @@ public:
 	// user defined info for each particle
 	vector<userInforForParticle> userInfo;
 
+	rerunEventParams rsp;
 
 	// these two should belong to a general generator class
 	// start time can be modeled
@@ -54,6 +72,8 @@ public:
 
 
 	bool isFileOpen() {return !gif.eof();}
+
+	bool doneRerun() { return (rsp.enabled && rsp.currentevent >= int(rsp.events.size())); }
 
 private:
 	string input_gen;                 ///< Input Option: internal or external

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -605,6 +605,14 @@ void goptions::setGoptions()
 	optMap["SAVE_SELECTED"].type  = 1;
 	optMap["SAVE_SELECTED"].ctgr  = "output";
 	
+	// Reruns saved events
+	optMap["RERUN_SELECTED"].args  = "";
+	optMap["RERUN_SELECTED"].help  = "Rerun saved events";
+	optMap["RERUN_SELECTED"].help  = "  arg is directory\n";
+	optMap["RERUN_SELECTED"].name  = "Rerun saved events";
+	optMap["RERUN_SELECTED"].type  = 1;
+	optMap["RERUN_SELECTED"].ctgr  = "control";
+
 	
 
 	// Physics

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -608,7 +608,7 @@ void goptions::setGoptions()
 	// Reruns saved events
 	optMap["RERUN_SELECTED"].args  = "";
 	optMap["RERUN_SELECTED"].help  = "Rerun saved events";
-	optMap["RERUN_SELECTED"].help  = "  arg is directory\n";
+	optMap["RERUN_SELECTED"].help  = "  arg is list of run #, [,directory]\n";
 	optMap["RERUN_SELECTED"].name  = "Rerun saved events";
 	optMap["RERUN_SELECTED"].type  = 1;
 	optMap["RERUN_SELECTED"].ctgr  = "control";


### PR DESCRIPTION
This branch improves upon the previously submitted "rerun" branch.

Defines a new option RERUN_SELECTED="&lt;run&gt;[,&lt;dir&gt;]". &lt;run&gt; is a run number; &lt;dir&gt; is a path to a directory, defaulting to "./".

This option causes GEMC to read files in the given directory with filenames of the form run&lt;run&gt;&lt;evt&gt;.rndm, in numerical order by event number &lt;evt&gt;, and use them to initialize the random number generator prior to the start of each event, thus rerunning the events. If not further limited by the N option, the run is terminated after the last such event is rerun.

If reading from a LUND generator input file, the lines corresponding to non-rerun events are skipped over so that the rerun events are started with the correct input.

Event numbers shown in output files are set to match those of the original events.
