### PR TITLE
Pbunch

### DIFF
--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -7,6 +7,7 @@
 #include "G4UnitsTable.hh"
 #include "Randomize.hh"
 #include "G4RunManager.hh"
+#include "G4Poisson.hh"
 
 // gemc headers
 #include "MPrimaryGeneratorAction.h"
@@ -831,15 +832,9 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 	// Luminosity Particles
 	int NBUNCHES   = (int) floor(TWINDOW/TBUNCH);
-	int PBUNCH     = (int) floor((double)NP/NBUNCHES) - 1;
+	double PBUNCHMEAN = (double)NP/NBUNCHES;
 
-
-	// there will be some remaining particles, these will be added at the last bunch
-	int NREMAINING = NP - NBUNCHES*PBUNCH;
-
-	// cout << PBUNCH << " " << NBUNCHES <<  " " << NBUNCHES*PBUNCH << " " << NREMAINING << endl;
-
-	if(PBUNCH > 0)
+	if(PBUNCHMEAN > 0)
 	{
 		particleGun->SetParticleDefinition(L_Particle);
 
@@ -850,6 +845,7 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 		double L_Phi   = L_phi;
 
 		// all particles in a bunch are identical
+		int pbsum = 0;
 		for(int b=0; b<NBUNCHES; b++)
 		{
 			// spread momentum if requested
@@ -888,13 +884,11 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 				lvz = L_vz + (2.0*G4UniformRand()-1.0)*L_dvz;
 			}
 
+			G4long PBUNCH = G4Poisson(PBUNCHMEAN);
+
 			particleGun->SetNumberOfParticles(PBUNCH);
-
-			if(b == NBUNCHES-1)
-				particleGun->SetNumberOfParticles(PBUNCH + NREMAINING);
-
-
-			// cout << " bunch " << b << " " << PBUNCH << endl;
+			pbsum += PBUNCH;
+			cout << " bunch " << b << " " << PBUNCH << " window sum  " << pbsum << endl;
 
 			particleGun->SetParticleTime(TBUNCH*b);
 			particleGun->SetParticlePosition(G4ThreeVector(lvx, lvy, lvz));
@@ -904,12 +898,12 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 	// Luminosity Particles2
 	int NBUNCHES2   = (int) floor(TWINDOW/TBUNCH2);
-	int PBUNCH2     = (int) floor((double)NP2/NBUNCHES2);
+	double PBUNCHMEAN2 = (double)NP2/NBUNCHES2;
 
-
-	if(PBUNCH2 > 0)
+	if(PBUNCHMEAN2 > 0)
 	{
 		particleGun->SetParticleDefinition(L2_Particle);
+		G4long PBUNCH = G4Poisson(PBUNCHMEAN2);
 		particleGun->SetNumberOfParticles(PBUNCH);
 
 		// getting kinematics

--- a/src/MPrimaryGeneratorAction.cc
+++ b/src/MPrimaryGeneratorAction.cc
@@ -845,7 +845,6 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 		double L_Phi   = L_phi;
 
 		// all particles in a bunch are identical
-		int pbsum = 0;
 		for(int b=0; b<NBUNCHES; b++)
 		{
 			// spread momentum if requested
@@ -884,11 +883,11 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 				lvz = L_vz + (2.0*G4UniformRand()-1.0)*L_dvz;
 			}
 
-			G4long PBUNCH = G4Poisson(PBUNCHMEAN);
+			G4long pbunch = G4Poisson(PBUNCHMEAN);
 
-			particleGun->SetNumberOfParticles(PBUNCH);
-			pbsum += PBUNCH;
-			cout << " bunch " << b << " " << PBUNCH << " window sum  " << pbsum << endl;
+			particleGun->SetNumberOfParticles(pbunch);
+
+			// cout << " bunch " << b << " " << pbunch << endl;
 
 			particleGun->SetParticleTime(TBUNCH*b);
 			particleGun->SetParticlePosition(G4ThreeVector(lvx, lvy, lvz));
@@ -903,8 +902,8 @@ void MPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 	if(PBUNCHMEAN2 > 0)
 	{
 		particleGun->SetParticleDefinition(L2_Particle);
-		G4long PBUNCH = G4Poisson(PBUNCHMEAN2);
-		particleGun->SetNumberOfParticles(PBUNCH);
+		G4long pbunch = G4Poisson(PBUNCHMEAN2);
+		particleGun->SetNumberOfParticles(pbunch);
 
 		// getting kinematics
 		double L2_mass  = L2_Particle->GetPDGMass();

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -605,8 +605,8 @@ void goptions::setGoptions()
 	// Activates RNG saving for selected events
 	optMap["SAVE_SELECTED"].args  = "";
 	optMap["SAVE_SELECTED"].help  = "Save events with selected hit types\n";
-	optMap["SAVE_SELECTED"].help  = "  arg is list of id, pid, low limit, high limit, variable[, directory]\n";
-	optMap["SAVE_SELECTED"].help  = "  e.g. 7xx10000, 11, 0.0*MeV, 2000*MeV, trackE, /.\n";
+	optMap["SAVE_SELECTED"].help  += "  arg is list of id, pid, low limit, high limit, variable[, directory]\n";
+	optMap["SAVE_SELECTED"].help  += "  e.g. 7xx10000, 11, 0.0*MeV, 2000*MeV, trackE, /.\n";
 	optMap["SAVE_SELECTED"].name  = "Save events with selected hit types";
 	optMap["SAVE_SELECTED"].type  = 1;
 	optMap["SAVE_SELECTED"].ctgr  = "output";
@@ -614,7 +614,7 @@ void goptions::setGoptions()
 	// Reruns saved events
 	optMap["RERUN_SELECTED"].args  = "";
 	optMap["RERUN_SELECTED"].help  = "Rerun saved events";
-	optMap["RERUN_SELECTED"].help  = "  arg is list of run #, [,directory]\n";
+	optMap["RERUN_SELECTED"].help  += "  arg is list of run #[, directory]\n";
 	optMap["RERUN_SELECTED"].name  = "Rerun saved events";
 	optMap["RERUN_SELECTED"].type  = 1;
 	optMap["RERUN_SELECTED"].ctgr  = "control";

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -605,8 +605,8 @@ void goptions::setGoptions()
 	// Activates RNG saving for selected events
 	optMap["SAVE_SELECTED"].args  = "";
 	optMap["SAVE_SELECTED"].help  = "Save events with selected hit types\n";
-	optMap["SAVE_SELECTED"].help  += "  arg is list of id, pid, low limit, high limit, variable[, directory]\n";
-	optMap["SAVE_SELECTED"].help  += "  e.g. 7xx10000, 11, 0.0*MeV, 2000*MeV, trackE, /.\n";
+	optMap["SAVE_SELECTED"].help  = "  arg is list of id, pid, low limit, high limit, variable[, directory]\n";
+	optMap["SAVE_SELECTED"].help  = "  e.g. 7xx10000, 11, 0.0*MeV, 2000*MeV, trackE, /.\n";
 	optMap["SAVE_SELECTED"].name  = "Save events with selected hit types";
 	optMap["SAVE_SELECTED"].type  = 1;
 	optMap["SAVE_SELECTED"].ctgr  = "output";
@@ -614,7 +614,7 @@ void goptions::setGoptions()
 	// Reruns saved events
 	optMap["RERUN_SELECTED"].args  = "";
 	optMap["RERUN_SELECTED"].help  = "Rerun saved events";
-	optMap["RERUN_SELECTED"].help  += "  arg is list of run #[, directory]\n";
+	optMap["RERUN_SELECTED"].help  = "  arg is list of run #, [,directory]\n";
 	optMap["RERUN_SELECTED"].name  = "Rerun saved events";
 	optMap["RERUN_SELECTED"].type  = 1;
 	optMap["RERUN_SELECTED"].ctgr  = "control";


### PR DESCRIPTION
The intent of this is to address issue #79. Instead of putting a fixed rounded number of lumi particles in each bunch and adding leftover particles to the last bunch, the number in each bunch is Poisson distributed with mean = NP*(TWINDOW/TBUNCH). This results in the number of particles in each window being equal to NP only on average, but there is no physics justification I can think of for using identically equal numbers of particles per window anyway.