### PR TITLE
Iss188 - Silence the evio deprecated warnings so other warning become visible.

### DIFF
--- a/output/outputFactory.h
+++ b/output/outputFactory.h
@@ -18,8 +18,11 @@
 #include "frequencySyncSignal.h"
 
 // EVIO
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations" 
 #include "evioUtil.hxx"
 #include "evioFileChannel.hxx"
+#pragma clang diagnostic pop
 using namespace evio;
 
 // geant4

--- a/output/outputFactory.h
+++ b/output/outputFactory.h
@@ -18,11 +18,12 @@
 #include "frequencySyncSignal.h"
 
 // EVIO
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations" 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations" 
+#pragma GCC diagnostic ignored "-Wdeprecated" 
 #include "evioUtil.hxx"
 #include "evioFileChannel.hxx"
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 using namespace evio;
 
 // geant4


### PR DESCRIPTION
Tested on MacOS Catalina with clang 12, and on ifarm1901 with gcc 9.2.
Relatively harmless changes.