### PR TITLE
add FILTER_BEAM to cut away events only recording beam particles

### DIFF
--- a/src/MEventAction.cc
+++ b/src/MEventAction.cc
@@ -92,6 +92,7 @@ MEventAction::MEventAction(goptions opts, map<string, double> gpars)
 	gPars            = gpars;
 	MAXP             = (int) gemcOpt.optMap["NGENP"].arg;
 	FILTER_HITS      = (int) gemcOpt.optMap["FILTER_HITS"].arg;
+	FILTER_BEAM      = (int) gemcOpt.optMap["FILTER_BEAM"].arg;	
 	FILTER_HADRONS   = (int) gemcOpt.optMap["FILTER_HADRONS"].arg;
 	FILTER_HIGHMOM   = (int) gemcOpt.optMap["FILTER_HIGHMOM"].arg;
 	SKIPREJECTEDHITS = (int) gemcOpt.optMap["SKIPREJECTEDHITS"].arg;
@@ -260,6 +261,38 @@ void MEventAction::EndOfEventAction(const G4Event* evt)
 		if(anyHit==0) return;
 	}
 	
+	if(FILTER_BEAM) {
+		int foundBeam = 0;
+// 		cout << SeDe_Map.size() << " SeDe_Map.size() " << endl; // always 1
+		for(map<string, sensitiveDetector*>::iterator it = SeDe_Map.begin(); it!= SeDe_Map.end(); it++) {
+			MHC = it->second->GetMHitCollection();
+			if (MHC) nhits = MHC->GetSize();
+			else nhits = 0;
+			if (nhits==1){
+			for (int h=0; h<nhits; h++)
+			{
+				vector<int>           tids = (*MHC)[h]->GetTIds();
+				vector<G4ThreeVector> mmts = (*MHC)[h]->GetMoms();				
+				int thiscounter=0;
+				for (vector<int>::const_iterator tit = tids.begin(); tit != tids.end(); tit++) {
+
+// 					cout << nhits << " " << tids.size() << " " << mmts.size() << " " << *tit << " " << mmts[thiscounter].z() << endl;				  
+					if (*tit ==1 && mmts[thiscounter].z()==FILTER_BEAM) {
+						foundBeam = 1;
+						break;
+					}
+					
+					thiscounter++;					
+				}				
+
+			}
+			}
+			
+		}
+		
+		// stop here if there are no hits and FILTER_HITS is set
+		if(foundBeam) return;
+	}
 	
 	// if FILTER_HADRONS is set, checking if there are any (matching) hadrons
 	if (FILTER_HADRONS == 1 || abs(FILTER_HADRONS) > 99) {

--- a/src/MEventAction.h
+++ b/src/MEventAction.h
@@ -153,7 +153,8 @@ public:
 	int SAVE_ALL_ANCESTORS; ///< Outputs info on all ancestors of tracks with hits
 	int MAXP;               ///< Max number of generated particles to save on output stream
 	int FILTER_HITS;        ///< If set to 1, do not write any output unless there is a hit somewhere
-	int FILTER_HADRONS;     ///< If set to 1, do not write any output unless there is a hadron somewhere
+	int FILTER_BEAM;        ///< If set to non-0, do not write any output when there is only a hit from beam
+	int FILTER_HADRONS;     ///< If set to non-0, do not write any output unless there is a hadron somewhere
 	int FILTER_HIGHMOM;     ///< If set to non-0, do not write any output unless there is high mom hit
 	int SKIPREJECTEDHITS;   ///< Skips hits that are rejected by digitization. Default: yes
 	string WRITE_ALLRAW;    ///< List of detectors for which geant4 all raw info need to be saved

--- a/src/gemc_options.cc
+++ b/src/gemc_options.cc
@@ -776,6 +776,12 @@ void goptions::setGoptions()
 	optMap["FILTER_HITS"].type = 0;
 	optMap["FILTER_HITS"].ctgr = "output";
 
+	optMap["FILTER_BEAM"].arg = 0;
+	optMap["FILTER_BEAM"].help = "If set to non-0, but as beam Mom in MeV, do not write output if there are only 1 hit from the beam";
+	optMap["FILTER_BEAM"].name = "If set to non-0, but as beam Mom in MeV, do not write output if there are only 1 hit from the beam";
+	optMap["FILTER_BEAM"].type = 0;
+	optMap["FILTER_BEAM"].ctgr = "output";
+	
 	optMap["FILTER_HADRONS"].arg = 0;
 	optMap["FILTER_HADRONS"].help = "If set to 1, do not write events if there are no hadrons. Otherwise if \n";
 	optMap["FILTER_HADRONS"].help += "nonzero write only events having a hadron with matching ID. For example\n";


### PR DESCRIPTION
this is to help reduce output size and increase speed when testing Geant4 physics by shooting beam particles into a target and recording all hits in the target 