### PR TITLE
Composite Field Value Calculation (Binary Maps)

### DIFF
--- a/fields/bclas12MappedField.cc
+++ b/fields/bclas12MappedField.cc
@@ -20,6 +20,14 @@ void gclas12BinaryMappedField::GetFieldValue(const double x[3], double *bField) 
 	// Uses David's routine to return the BX BY BZ components
 
 
+        FieldValuePtr combinedValuePtr = (FieldValuePtr) malloc(sizeof (FieldValue));
+	getCompositeFieldValue(combinedValuePtr, x[0], x[1], x[2], torus, solenoid);//torus and solenoid were declared in the header file
+	bField[0] = combinedValuePtr->b1;
+        bField[1] = combinedValuePtr->b2;
+        bField[2] = combinedValuePtr->b3;
+
+
+
 	// we don't worry about computer speed
 	// if verbosity is set this high
 	// so we can output units as well
@@ -80,6 +88,9 @@ void gclas12BinaryMappedField::initializeMap()
 	sinGamma = sin(mapRotation[2]);
 	cosGamma = cos(mapRotation[2]);	
 }
+
+
+
 
 
 

--- a/fields/bclas12MappedField.h
+++ b/fields/bclas12MappedField.h
@@ -57,7 +57,6 @@ public:
 
 	FieldValuePtr torusValuePtr;
 	FieldValuePtr solenoidValuePtr;
-	FieldValuePtr combinedValuePtr;
 
 	// precalculating values of the rotation angles so we don't do it at GetFieldValue time
 	double sinAlpha, cosAlhpa;

--- a/fields/bclas12MappedField.h
+++ b/fields/bclas12MappedField.h
@@ -7,7 +7,10 @@
 
 // G4 headers
 #include "G4MagneticField.hh"
-
+#include "magfield.h"
+#include "magfieldio.h"
+#include "munittest.h"
+#include "magfieldutil.h"
 
 // c++ headers
 #include <vector>
@@ -57,6 +60,7 @@ public:
 
 	FieldValuePtr torusValuePtr;
 	FieldValuePtr solenoidValuePtr;
+	FieldValuePtr combinedValuePtr;
 
 	// precalculating values of the rotation angles so we don't do it at GetFieldValue time
 	double sinAlpha, cosAlhpa;
@@ -81,6 +85,12 @@ public:
 };
 
 #endif
+
+
+
+
+
+
 
 
 

--- a/fields/bclas12MappedField.h
+++ b/fields/bclas12MappedField.h
@@ -51,7 +51,14 @@ public:
 
 	// returns the field at point x. This is a dispatcher for the various symmetries below
 	void GetFieldValue( const double x[3], double *Bfield) const;
-	
+
+	static MagneticFieldPtr torus;
+	static MagneticFieldPtr solenoid;
+
+	FieldValuePtr torusValuePtr;
+	FieldValuePtr solenoidValuePtr;
+	FieldValuePtr combinedValuePtr;
+
 	// precalculating values of the rotation angles so we don't do it at GetFieldValue time
 	double sinAlpha, cosAlhpa;
 	double sinBeta, cosBeta;
@@ -75,6 +82,7 @@ public:
 };
 
 #endif
+
 
 
 


### PR DESCRIPTION
The CMAG utilities are implemented for the calculation of the composite field value using the Torus and Solenoid pointers.  