### PR TITLE
RICH updates: making timing consistent with ccdb + adding background hits

### DIFF
--- a/hitprocess/clas12/rich_hitprocess.cc
+++ b/hitprocess/clas12/rich_hitprocess.cc
@@ -106,22 +106,21 @@ map<string, double> rich_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 	  double duration = identity[2].userInfos[1];
 	  // leading edge:
 	  if(order==1){ 
-	    tdc = 0 + G4RandGauss::shoot(richc.timeOffsetCorr[idpmt-1], 1); // 1ns time resol. smearing (SHOULD BE THE SAME FOR BOTH?)
+	    tdc = int(time[0]) + 0 + G4RandGauss::shoot(richc.timeOffsetCorr[idpmt-1], 1); // 1ns time resol. smearing (SHOULD BE THE SAME FOR BOTH?)
 	  }
 	  if(order==0){
-
 	    // should we smear time walk corrections a little, presumably? duration is already kinda smeared
 	    double f1 = richc.timewalkCorr_m1[idpmt-1] * duration + richc.timewalkCorr_T0[idpmt-1];
 	    double f1T = richc.timewalkCorr_m1[idpmt-1] * richc.timewalkCorr_D0[idpmt-1] + richc.timewalkCorr_T0[idpmt-1];	    
 	    double f2 = richc.timewalkCorr_m2[idpmt-1] * (duration - richc.timewalkCorr_D0[idpmt-1]) + f1T;
-	    cout << "f1: " << f1 << " f1T: " << f1T << " f2: " << f2 << endl;
+	    
 	    if(duration < richc.timewalkCorr_D0[idpmt-1]){
-	      tdc = duration
+	      tdc = int(time[0]) + duration
 		+ G4RandGauss::shoot(richc.timeOffsetCorr[idpmt-1], 1)
 		- f1;
 	    }
 	    else{
-	      tdc = duration
+	      tdc = int(time[0]) + duration
 		+ G4RandGauss::shoot(richc.timeOffsetCorr[idpmt-1], 1)
 		- f2;
 	    }
@@ -131,8 +130,7 @@ map<string, double> rich_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 	else{
 	  tdc = identity[2].userInfos[1] + int(time[0]);
 	}
-
-	cout << "order: " << order << " tdc: " << tdc << endl;
+	
 	writeHit = true;
 	rejectHitConditions = false;
 	

--- a/hitprocess/clas12/rich_hitprocess.cc
+++ b/hitprocess/clas12/rich_hitprocess.cc
@@ -49,14 +49,15 @@ static richConstants initializeRICHConstants(int runno, string digiVariation = "
 	for(unsigned int row = 0; row<data.size(); row++){	  
 	  int ipmt = data[row][1];
 	  richc.timewalkCorr_D0[ipmt-1] = data[row][3];
-	  richc.timewalkCorr_m1[ipmt-1]	= data[row][4];
-	  richc.timewalkCorr_m2[ipmt-1]	= data[row][5];
-	  richc.timewalkCorr_T0[ipmt-1]	= data[row][6];
-	  //cout << "D0 pmt " << ipmt << " : " << richc.timewalkCorr_D0[ipmt-1] << endl;
-          //cout << "m1 pmt " << ipmt << " : " << richc.timewalkCorr_m1[ipmt-1] << endl;
-          //cout << "m2 pmt " << ipmt << " : " << richc.timewalkCorr_m2[ipmt-1] << endl;
-          //cout << "T0 pmt " << ipmt << " : " << richc.timewalkCorr_T0[ipmt-1] << endl;
-
+	  richc.timewalkCorr_m1[ipmt-1]	= data[row][5];
+	  richc.timewalkCorr_m2[ipmt-1]	= data[row][6];
+	  richc.timewalkCorr_T0[ipmt-1]	= data[row][4];
+	  if(ipmt == 1){
+	    cout << "D0 pmt " << ipmt << " : " << richc.timewalkCorr_D0[ipmt-1] << endl;
+	    cout << "m1 pmt " << ipmt << " : " << richc.timewalkCorr_m1[ipmt-1] << endl;
+	    cout << "m2 pmt " << ipmt << " : " << richc.timewalkCorr_m2[ipmt-1] << endl;
+	    cout << "T0 pmt " << ipmt << " : " << richc.timewalkCorr_T0[ipmt-1] << endl;	    
+	  }
 	}	
 
 	data.clear();
@@ -68,7 +69,9 @@ static richConstants initializeRICHConstants(int runno, string digiVariation = "
         for(unsigned int row = 0; row<data.size(); row++){
           int ipmt = data[row][1];
           richc.timeOffsetCorr[ipmt-1] = data[row][3];
-	  //cout << "time offset pmt " << ipmt << " : " << richc.timeOffsetCorr[ipmt-1] << endl;
+	  if(ipmt == 1){
+	    cout << "time offset pmt " << ipmt << " : " << richc.timeOffsetCorr[ipmt-1] << endl;
+	  }
         }
 
 	return richc;
@@ -113,7 +116,7 @@ map<string, double> rich_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 	    double f1 = richc.timewalkCorr_m1[idpmt-1] * duration + richc.timewalkCorr_T0[idpmt-1];
 	    double f1T = richc.timewalkCorr_m1[idpmt-1] * richc.timewalkCorr_D0[idpmt-1] + richc.timewalkCorr_T0[idpmt-1];	    
 	    double f2 = richc.timewalkCorr_m2[idpmt-1] * (duration - richc.timewalkCorr_D0[idpmt-1]) + f1T;
-	    
+	    cout << "f1: " << f1 << " f1T: " << f1T << " f2: " << f2 << endl;
 	    if(duration < richc.timewalkCorr_D0[idpmt-1]){
 	      tdc = int(time[0]) + duration
 		+ G4RandGauss::shoot(richc.timeOffsetCorr[idpmt-1], 1)

--- a/hitprocess/clas12/rich_hitprocess.cc
+++ b/hitprocess/clas12/rich_hitprocess.cc
@@ -109,15 +109,15 @@ map<string, double> rich_HitProcess :: integrateDgt(MHit* aHit, int hitn)
 	  double duration = identity[2].userInfos[1];
 	  // leading edge:
 	  if(order==1){ 
-	    tdc = int(time[0]) + 0 + G4RandGauss::shoot(richc.timeOffsetCorr[idpmt-1], 1); // 1ns time resol. smearing (SHOULD BE THE SAME FOR BOTH?)
+	    tdc = int(time[0]) + 0 + G4RandGauss::shoot(richc.timeOffsetCorr[idpmt-1], 1.); // 1ns time resol. smearing (SHOULD BE THE SAME FOR BOTH?)
 	  }
 	  if(order==0){
 	    // should we smear time walk corrections a little, presumably? duration is already kinda smeared
 	    double f1 = richc.timewalkCorr_m1[idpmt-1] * duration + richc.timewalkCorr_T0[idpmt-1];
 	    double f1T = richc.timewalkCorr_m1[idpmt-1] * richc.timewalkCorr_D0[idpmt-1] + richc.timewalkCorr_T0[idpmt-1];	    
 	    double f2 = richc.timewalkCorr_m2[idpmt-1] * (duration - richc.timewalkCorr_D0[idpmt-1]) + f1T;
-	    //cout << "f1: " << f1 << " f1T: " << f1T << " f2: " << f2 << endl;
-	    if(duration < richc.timewalkCorr_D0[idpmt-1]){
+
+	    if(duration < richc.D0pmtSim){
 	      tdc = int(time[0]) + duration
 		+ G4RandGauss::shoot(richc.timeOffsetCorr[idpmt-1], 1)
 		- f1;
@@ -187,6 +187,8 @@ vector<identifier> rich_HitProcess :: processID(vector<identifier> id, G4Step* a
 	
         int pmt = yid[1].id;
 	RichPixel richPixel(richc.pmtType[pmt-1]);
+
+	cout << "pmt: " << pmt << " pixel: " << pixel << "pixel center global: " << pixelCenterGlobal.x() << " " << pixelCenterGlobal.y() << " " << pixelCenterGlobal.z() << endl;
 
 	richPixel.Clear();
 	

--- a/hitprocess/clas12/rich_hitprocess.h
+++ b/hitprocess/clas12/rich_hitprocess.h
@@ -169,6 +169,9 @@ public:
   double timewalkCorr_T0[npmt];
   double timeOffsetCorr[npmt];
 
+  // mean D0 (time walk parameter) from sim of PMT with RichPixel class
+  // determined by running time calibration suite over electrons thrown in RICH
+  double D0pmtSim = 55.0;   
 
   // dark hit constants
   double darkRate = 500*hertz;

--- a/hitprocess/clas12/rich_hitprocess.h
+++ b/hitprocess/clas12/rich_hitprocess.h
@@ -157,14 +157,26 @@ public:
   // translation table
   TranslationTable TT;
 
-  // add constants here
+
+
   const static int npmt = 391;
   const static int npixel = 64;
+  
+  // ccdb time constants
   double timewalkCorr_D0[npmt];
   double timewalkCorr_m1[npmt];
   double timewalkCorr_m2[npmt];
   double timewalkCorr_T0[npmt];
   double timeOffsetCorr[npmt];
+
+
+  // dark hit constants
+  double darkRate = 500*hertz;
+  double timeWindowDefault = 248.5*ns; // can we access this somehow?
+  double avgNDarkHits = darkRate*timeWindowDefault*npmt*npixel;
+
+  
+  // readout electronics translation constants
   // anode->maroc and pmt->board constants
 
   // anode->maroc

--- a/hitprocess/clas12/rich_hitprocess.h
+++ b/hitprocess/clas12/rich_hitprocess.h
@@ -327,7 +327,10 @@ private:
 
         // RICH specific functions 
         int getPixelNumber(G4ThreeVector  Lxyz);
-        G4ThreeVector getPixelCenter(int pixel);        
+        G4ThreeVector getPixelCenter(int pixel);
+
+        // testing ccdb time paramters vs PMT simulation class
+        bool ccdbTiming = true;
 };
 
 #endif


### PR DESCRIPTION
Current RICH digitization produced TDC values from a simulation of the PMT avalanche itself, which produces realistic timing results but is not necessarily consistent with the time walk and time offset parameters in the ccdb. This PR will introduce an option to instead produce TDC values based on the time calibration parameters from the ccdb.

Additionally, this PR implements RICH dark current hits based on a 500Hz dark rate across all pixels. 