### PR TITLE
fixed the ALERT data banks names to AHDC::adc, ATOF::adc

### DIFF
--- a/hitprocess/HitProcess_MapRegister.cc
+++ b/hitprocess/HitProcess_MapRegister.cc
@@ -68,8 +68,10 @@ map<string, HitProcess_Factory> HitProcess_Map(string experiments)
 		
 		// CLAS12
 		if(EXP == "clas12") {
-			hitMap["alrttof"]   = &atof_HitProcess::createHitClass;
-			hitMap["alrtdc"]    = &ahdc_HitProcess::createHitClass;
+			// hitMap["alrttof"]   = &atof_HitProcess::createHitClass;
+			// hitMap["alrtdc"]    = &ahdc_HitProcess::createHitClass;
+			hitMap["atof"]   = &atof_HitProcess::createHitClass;
+			hitMap["ahdc"]    = &ahdc_HitProcess::createHitClass;
 			//hitMap["alertshell"] = &alertshell_HitProcess::createHitClass;
 			hitMap["band"]	     = &band_HitProcess::createHitClass;
 			hitMap["bmt"]       = &BMT_HitProcess::createHitClass;

--- a/output/hipo_output.h
+++ b/output/hipo_output.h
@@ -118,8 +118,8 @@ public:
 		{"rtpc",    19},
 		{"band",    21},
 		{"urwell",  23},
-		{"alrttof", 24},
-		{"alrtdc",  25},
+		{"atof",    24},
+		{"ahdc",    25},
 		{"flux",   100}
 	};
 


### PR DESCRIPTION
Data bank names were changed from alrtdc -> ahdc, alrttof -> atof in:
 - hitprocess/HitProcess_MapRegister.cc
 - output/hipo_output.h