### PR TITLE
Enable Mie scattering in gemc

### DIFF
--- a/materials/material_factory.cc
+++ b/materials/material_factory.cc
@@ -126,6 +126,18 @@ void material::opticalsFromString(string property, string what) {
             if (what == "rayleigh")
                 rayleigh.push_back(get_number(trimmedC));
 
+            if (what == "mie")
+                mie.push_back(get_number(trimmedC));
+
+            if (what == "mieforward")
+                mieforward = get_number(trimmedC);
+
+            if (what == "miebackward")
+                miebackward = get_number(trimmedC);
+
+            if (what == "mieratio")
+                mieratio = get_number(trimmedC);
+
             if (what == "birkConstant")
                 birkConstant = get_number(trimmedC);
         }
@@ -141,6 +153,7 @@ void material::opticalsFromString(string property, string what) {
             if (fastcomponent.size() != photonEnergy.size()) fastcomponent.clear();
             if (slowcomponent.size() != photonEnergy.size()) slowcomponent.clear();
             if (rayleigh.size() != photonEnergy.size()) rayleigh.clear();
+            if (mie.size() != photonEnergy.size()) mie.clear();
         }
 
     }
@@ -369,6 +382,15 @@ map<string, G4Material *> materials::materialsFromMap(map <string, material> mma
                         optTable.back()->AddProperty("RAYLEIGH", penergy, ray, nopts);
                     }
 
+                    // mie scattering
+                    if (it->second.mie.size() == nopts) {
+                        double mie[nopts];
+                        for (unsigned i = 0; i < nopts; i++)
+                            mie[i] = it->second.mie[i];
+
+                        optTable.back()->AddProperty("MIEHG", penergy, mie, nopts);
+                    }
+		    
 
 
                     // in the API -1 is the default
@@ -396,6 +418,16 @@ map<string, G4Material *> materials::materialsFromMap(map <string, material> mma
                     // birkConstant - must be in mm / MeV
                     if (it->second.birkConstant != -1)
                         mats[it->first]->GetIonisation()->SetBirksConstant(it->second.birkConstant);
+
+                    // additional mie scattering constants
+                    if (it->second.miebackward != -1)
+		        optTable.back()->AddConstProperty("MIEHG_BACKWARD", it->second.miebackward);
+		    
+		    if (it->second.mieforward != -1)
+		        optTable.back()->AddConstProperty("MIEHG_FORWARD", it->second.mieforward);
+		    
+		    if (it->second.mieratio != -1)
+		        optTable.back()->AddConstProperty("MIEHG_FORWARD_RATIO", it->second.mieratio);		    
 
                     mats[it->first]->SetMaterialPropertiesTable(optTable.back());
                 }

--- a/materials/material_factory.h
+++ b/materials/material_factory.h
@@ -33,6 +33,12 @@ class material
 		vector<double> absorptionLength;
 		vector<double> reflectivity;
 		vector<double> efficiency;
+		
+		// mie scattering
+		vector<double> mie;
+		double mieforward;
+		double miebackward;
+		double mieratio;
 
 		// scintillation
 		vector<double> fastcomponent;

--- a/materials/mysql_materials.cc
+++ b/materials/mysql_materials.cc
@@ -52,7 +52,8 @@ map<string, G4Material*> mysql_materials::initMaterials(runConditions rc, goptio
 
 		string dbexecute  = "select name, description, density, ncomponents, components, photonEnergy, indexOfRefraction, ";
 				 dbexecute += "absorptionLength, reflectivity, efficiency, fastcomponent, slowcomponent, ";
-				 dbexecute += "scintillationyield, resolutionscale, fasttimeconstant, slowtimeconstant, yieldratio from " + tname;
+				 dbexecute += "scintillationyield, resolutionscale, fasttimeconstant, slowtimeconstant, yieldratio, rayleigh, birkConstant, ";
+				 dbexecute += "mie, mieforward, miebackward, mieratio from " + tname;
 				 dbexecute += " where variation ='" + variation + "'";
 				
 		// executing query - will exit if not successfull.
@@ -93,6 +94,12 @@ map<string, G4Material*> mysql_materials::initMaterials(runConditions rc, goptio
 
 			// Birk Constant
 			thisMat.birkConstant       =             q.value(18).toDouble(); // yieldratio
+
+			// Mie scattering
+			thisMat.opticalsFromString(qv_tostring(  q.value(19)), "mie");
+			thisMat.mieforward       =             q.value(20).toDouble(); // mie forward scattering
+			thisMat.miebackward       =             q.value(21).toDouble(); // mie backward scattering
+			thisMat.mieratio       =             q.value(22).toDouble(); // mie forward/backward scattering ratio
 
 			mymats[thisMat.name] = thisMat;
 			

--- a/materials/sqlite_materials.cc
+++ b/materials/sqlite_materials.cc
@@ -52,7 +52,8 @@ map<string, G4Material *> sqlite_materials::initMaterials(runConditions rc, gopt
 
         string dbexecute = "select name, description, density, ncomponents, components, photonEnergy, indexOfRefraction, ";
         dbexecute += "absorptionLength, reflectivity, efficiency, fastcomponent, slowcomponent, ";
-        dbexecute += "scintillationyield, resolutionscale, fasttimeconstant, slowtimeconstant, yieldratio from materials";
+        dbexecute += "scintillationyield, resolutionscale, fasttimeconstant, slowtimeconstant, yieldratio, rayleigh, birkconstant, "; // rayleigh and birk constant were not here?
+        dbexecute += "mie, mieforward, miebackward, mieratio from materials";
         dbexecute += " where variation ='" + variation + "'";
         dbexecute += " and run = " + stringify(run_number);
         dbexecute += " and system = '" + dname + "'";
@@ -70,7 +71,7 @@ map<string, G4Material *> sqlite_materials::initMaterials(runConditions rc, gopt
         }
 
         while (q.next()) {
-            material thisMat(trimSpacesFromString(qv_tostring( q.value(0))));         // name
+	    material thisMat(trimSpacesFromString(qv_tostring( q.value(0))));         // name
             thisMat.desc = qv_tostring(q.value(1));                                   // description
             thisMat.density = q.value(2).toDouble();                                  // density
             thisMat.ncomponents = q.value(3).toInt();                                 // number of components
@@ -93,6 +94,12 @@ map<string, G4Material *> sqlite_materials::initMaterials(runConditions rc, gopt
 
             // Birk Constant
             thisMat.birkConstant = q.value(18).toDouble();
+
+	    // Mie scattering
+            thisMat.opticalsFromString(qv_tostring(q.value(19)), "mie");
+            thisMat.mieforward = q.value(20).toDouble();
+            thisMat.miebackward = q.value(21).toDouble();
+            thisMat.mieratio = q.value(22).toDouble();
 
             mymats[thisMat.name] = thisMat;
 

--- a/materials/text_materials.cc
+++ b/materials/text_materials.cc
@@ -110,7 +110,16 @@ map<string, G4Material *> text_materials::initMaterials(runConditions rc, goptio
             if (gt.data.size() > 18) {
                 thisMat.birkConstant = get_number(gt.data[18]);
             }
-
+            // this condition is for backward compatibility,
+            // Birk Constant were added with gemc 2.6
+            // 23 exact quantities
+            if (gt.data.size() > 19) {
+	      thisMat.opticalsFromString(gt.data[19], "mie");
+	      thisMat.mieforward = get_number(gt.data[20]);
+	      thisMat.miebackward = get_number(gt.data[21]);
+	      thisMat.mieratio = get_number(gt.data[22]);
+            }
+	    
             mymats[thisMat.name] = thisMat;
 
         }

--- a/physics/PhysicsList.cc
+++ b/physics/PhysicsList.cc
@@ -386,7 +386,10 @@ void PhysicsList::cookPhysics()
 		// see G4OpticalPhysics.hh
 
 		G4OpticalPhysics* opticalPhysics = new G4OpticalPhysics();
-
+		// enable Mie scattering (do not think it is enabled by default)
+		// make this optional?
+		opticalPhysics->Configure(kMieHG, true);
+		
 		// this was deprecated?
 		// Method G4OpticalPhysics::SetWLSTimeProfile is deprecated.
 		// Use G4OpticalParameters::SetWLSTimeProfile(G4String) instead.


### PR DESCRIPTION
We would like to incorporate Mie/forward scattering effects in the RICH aerogel, but Mie scattering parameters are not currently handled in the gemc material definition. This PR will aim to add the Mie scattering parameters to the list of optical parameters loaded for a material, and add Mie scattering to the optical physics list.